### PR TITLE
Perf: cache per-command argspecs and batch the login state-dump

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -56,7 +56,7 @@ class Client():
 
 		# server<->client comms
 		self.buffersend = False # if True, write all sends to a buffer (must not be used when a client is logging in but didn't yet receive full server state!)
-		self.buffer = ""
+		self.buffer = [] # list of message strings (incl. trailing newline); joined once in flushBuffer
 		self.msg_id = ''
 		self.msg_sendbuffer = []
 		self.sendingmessage = ''
@@ -222,20 +222,27 @@ class Client():
 		self._root.outbound_command_stats[command] = self._root.outbound_command_stats.get(command, 0) + 1
 
 		#logging.info("> [" + self.username + " " + str(self.session_id) + "] " + data.strip()) # uncomment for debugging
-		
-		self.transport.write(data.encode("utf-8") + b"\n")
+
+		# while buffersend is on (the login state-dump), accumulate into the buffer
+		# and let flushBuffer emit it in a single transport.write. Stats are counted
+		# above either way, and no msg_id is prepended, so the bytes are identical to
+		# sending each message directly - only the syscall batching differs.
+		if self.buffersend:
+			self.buffer.append(data + "\n")
+		else:
+			self.transport.write(data.encode("utf-8") + b"\n")
 
 	def Send(self, data):
 		if self.msg_id:
 			data = self.msg_id + data
 		if self.buffersend:
-			self.buffer += data + "\n"
+			self.buffer.append(data + "\n")
 		else:
 			self.RealSend(data)
 
 	def flushBuffer(self):
-		self.transport.write(self.buffer.encode("utf-8"))
-		self.buffer = ""
+		self.transport.write("".join(self.buffer).encode("utf-8"))
+		self.buffer = []
 		self.buffersend = False
 
 	def isAdmin(self):

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -222,7 +222,12 @@ class Protocol:
 
 		self.restricted = restricted
 		self.restricted_list = restricted_list
-		
+
+		# per-command argspec cache: command -> (total_args, optional_args).
+		# getfullargspec is expensive and the result never changes for a given
+		# handler, so we memoise it lazily on first dispatch (see get_function_args).
+		self._argspec_cache = {}
+
 		self.ipRegex = r"^([01]?\d\d?|2[0-4]\d|25[0-5])\.([01]?\d\d?|2[0-4]\d|25[0-5])\.([01]?\d\d?|2[0-4]\d|25[0-5])\.([01]?\d\d?|2[0-4]\d|25[0-5])$"
 		self.ipRegex_compiled = re.compile(self.ipRegex)
 		
@@ -321,18 +326,21 @@ class Protocol:
 
 
 	def get_function_args(self, client, command, function, numspaces, args):
-		function_info = inspect.getfullargspec(function)
-		total_args = len(function_info[0]) - 2
+		# total_args (handler args minus self+client) and optional_args (those
+		# with defaults) are fixed per handler, so compute once and memoise.
+		spec = self._argspec_cache.get(command)
+		if spec is None:
+			function_info = inspect.getfullargspec(function)
+			total_args = len(function_info[0]) - 2
+			optional_args = len(function_info[3]) if function_info[3] else 0
+			spec = (total_args, optional_args)
+			self._argspec_cache[command] = spec
+		total_args, optional_args = spec
 
 		# if there are no arguments, just call the function
 		# with client as its only arg: *([client]) = client
 		if (total_args <= 0):
 			return True, []
-
-		# check for optional arguments
-		optional_args = 0
-		if function_info[3]:
-			optional_args = len(function_info[3])
 
 		# check if we've got enough words for filling the required args
 		required_args = total_args - optional_args

--- a/tests/stresstest.py
+++ b/tests/stresstest.py
@@ -2,7 +2,7 @@
 # coding=utf-8
 # This file is part of the uberserver (GPL v2 or later), see LICENSE
 
-import socket, inspect
+import socket, inspect, errno
 import time
 import threading
 import traceback
@@ -101,7 +101,9 @@ class LobbyClient:
 		try:
 			self.socket_data += self.host_socket.recv(4096).decode("utf-8")
 		except BlockingIOError as e:
-			if e.errno == 11: # Resource temporarily unavailable
+			# no data available yet on the non-blocking socket: EAGAIN (errno 11
+			# on Linux) or EWOULDBLOCK (errno 35 on macOS/BSD)
+			if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
 				return
 			raise(e)
 
@@ -140,7 +142,7 @@ class LobbyClient:
 
 		funcname = 'in_%s' % command
 		function = getattr(self, funcname)
-		function_info = inspect.getargspec(function)
+		function_info = inspect.getfullargspec(function)
 		total_args = len(function_info[0]) - 1
 		optional_args = 0
 


### PR DESCRIPTION
Two independent, low-risk optimizations (OPTIMIZATIONS.md 1.6 and 1.7) with no protocol or wire change, plus the macOS/Python-3.11 fixes needed to run the in-repo load test for verification.

## 1.6 - Cache per-command argspecs (`protocol/Protocol.py`)

`get_function_args` called `inspect.getfullargspec` on **every** command dispatch, though a handler's argument counts never change. The `(total_args, optional_args)` pair is now computed once per command and memoised in `self._argspec_cache`, then looked up O(1). The cached values are exactly what `getfullargspec` produced before, so dispatch behaviour is unchanged.

## 1.7 - Batch the login state-dump (`Client.py`)

`_SendLoginInfo` sends each ADDUSER/ADDBATTLE/JOINEDBATTLE/CLIENTSTATUS line via `RealSend` - one `transport.write` syscall per message - even though `buffersend` is already enabled for the dump. `RealSend` now honours `buffersend`: while set, it accumulates messages into the buffer and `flushBuffer` emits them in a single write.

`RealSend` (not `Send`) is buffered deliberately, to keep the bytes identical: `Send` prepends `msg_id` and its buffered path skips the `outbound_command_stats` update, whereas `RealSend` adds no id and always counts stats. **Wire bytes and message order are unchanged - only syscall batching differs.**

Also switches `Client.buffer` from O(n^2) string concatenation to a list joined once in `flushBuffer`.

## macOS / Python 3.11 (`tests/stresstest.py`)

Two portability fixes so the load test runs for verification outside Linux/old Python: accept `EWOULDBLOCK` (errno 35) as well as `EAGAIN` in `Recv`, and replace the removed `inspect.getargspec` with `getfullargspec`.

## Verification

- **1.7 byte-identicality (isolated):** drove an identical 11-message dump through both the old (direct) and new (buffered) `RealSend` paths of the real `Client` methods. Result: output bytes identical, write count collapses 11 -> 1, `outbound_command_stats` identical, `buffersend`/buffer reset after flush. Also confirmed `Send()` *would* have prepended `msg_id` (why the dump stays on `RealSend`).
- **End-to-end login:** ran the server locally (sqlite) and logged in with a captured client; the dump arrives well-formed and correctly ordered (ACCEPTED -> MOTD -> ADDUSER... -> CLIENTSTATUS -> LOGININFOEND), login completes, no server errors.
- **1.6 + dispatch:** the same logins plus the stresstest exercised LOGIN/CONFIRMAGREEMENT/REGISTER/OPENBATTLE/EXIT through the cached dispatch path with no errors or argument-bunching regressions.
- **stresstest fixes:** with both portability fixes the client runs without crashing and the server processes its commands (previously it crashed on `BlockingIOError` then on `getargspec`).

Each optimization is its own commit; the stresstest fixes are a third commit.