### PR TITLE
Bound per-client write buffers against slow readers (OPTIMIZATIONS 2.3)

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -70,6 +70,17 @@ class DataHandler:
 		self.trusted_proxyfile = None
 
 		self.pool_size = 50
+
+		# 2.3: bound per-client write buffers (slow-loris / stalled-reader DoS guard).
+		# transport.write() queues unsent data in memory with no bound, so a client
+		# that stops reading lets its server-side buffer grow without limit. We register
+		# each connection as a streaming producer: when its send buffer exceeds the
+		# high-water mark Twisted calls pauseProducing(); if it never drains (resumeProducing)
+		# within the grace period the client is dropped. A healthy client - including one
+		# receiving a large login state-dump - drains in milliseconds and is never affected.
+		self.write_buffer_highwater = 256 * 1024  # bytes queued before backpressure trips
+		self.write_buffer_grace = 30              # seconds a client may stay backed up before disconnect
+
 		self.sqlurl = 'sqlite:///server.db'
 		self.nextbattle = 0
 		self.SayHooks = __import__('SayHooks')

--- a/twistedserver.py
+++ b/twistedserver.py
@@ -1,5 +1,6 @@
 from twisted.internet.protocol import Factory
 from twisted.internet import protocol
+from twisted.internet import reactor
 from twisted.protocols.policies import TimeoutMixin
 from protocol import Protocol
 import DataHandler
@@ -16,6 +17,9 @@ class Chat(protocol.Protocol, Client.Client, TimeoutMixin):
 	def __init__(self, root):
 		self.root = root
 		self.TLS = False
+		# 2.3: pending reactor call that disconnects this client if its write
+		# buffer stays backed up past the grace period (None when not backed up).
+		self._write_overflow_call = None
 		assert(self.root.userdb != None)
 
 	def connectionMade(self):
@@ -34,6 +38,12 @@ class Chat(protocol.Protocol, Client.Client, TimeoutMixin):
 			self.setTimeout(60)
 			peer = (self.transport.getPeer().host, self.transport.getPeer().port)
 			Client.Client.__init__(self, self.root, peer, self.session_id)
+			# 2.3: bound the per-client send buffer. Raise the high-water mark above
+			# Twisted's 64KB default so a large login state-dump to a healthy client
+			# doesn't needlessly trip it, then register as a streaming producer so
+			# pauseProducing/resumeProducing tell us when a client stops reading.
+			self.transport.bufferSize = self.root.write_buffer_highwater
+			self.transport.registerProducer(self, True)
 			self.root.protocol._new(self)
 		except Exception as e:
 			logging.error("Error in adding client: %s %s %s" %(str(e), self.transport.getPeer().host, str(traceback.format_exc())))
@@ -42,8 +52,42 @@ class Chat(protocol.Protocol, Client.Client, TimeoutMixin):
 	def connectionLost(self, reason):
 		if not hasattr(self, 'session_id'): # this func is called after a client has dc'ed
 			return
+		self._cancelWriteOverflow()
 		self.root.protocol._remove(self, str(reason.value))
 		del self.root.clients[self.session_id]
+
+	##
+	## 2.3: write-buffer backpressure (IPushProducer)
+	##
+	## We are registered as a streaming producer on our own transport, so Twisted
+	## calls pauseProducing() when the send buffer exceeds write_buffer_highwater
+	## and resumeProducing() once it has fully drained. We can't actually pause the
+	## source (broadcasts are pushed from other clients), so instead we treat a
+	## sustained backlog as a stalled/slow reader and disconnect it after a grace
+	## period. A momentary backlog (e.g. a big login dump in flight) drains and
+	## cancels the timer, so healthy clients are never dropped.
+
+	def pauseProducing(self):
+		if self._write_overflow_call is None:
+			self._write_overflow_call = reactor.callLater(self.root.write_buffer_grace, self._writeBufferOverflow)
+
+	def resumeProducing(self):
+		self._cancelWriteOverflow()
+
+	def stopProducing(self):
+		self._cancelWriteOverflow()
+
+	def _cancelWriteOverflow(self):
+		if self._write_overflow_call is not None:
+			if self._write_overflow_call.active():
+				self._write_overflow_call.cancel()
+			self._write_overflow_call = None
+
+	def _writeBufferOverflow(self):
+		self._write_overflow_call = None
+		logging.info("disconnecting slow/stalled reader %s (%s): write buffer over %i bytes for %is" % (
+			getattr(self, 'username', '') or '?', self.ip_address, self.root.write_buffer_highwater, self.root.write_buffer_grace))
+		self.transport.abortConnection()
 
 	def removePWs(self, data):
 		# remove pw from LOGIN msg, to avoid appearing in logfile


### PR DESCRIPTION
## What

Phase 2, item 2.3 of OPTIMIZATIONS.md: bound the per-client write buffer to remove a slow-reader / slow-loris memory-exhaustion DoS vector.

Twisted's `transport.write()` is non-blocking and queues unsent data in memory with no bound. A client that stops reading - a slow connection, a slow-loris, or a crashed client holding the socket open - causes its server-side write buffer to grow without limit. With thousands of connections a handful of stalled readers can exhaust RAM. This is independent of the lobby protocol.

## How

Each connection is registered as a streaming producer on its own transport (`registerProducer`). Twisted then calls:

- `pauseProducing()` when the connection's send buffer exceeds the high-water mark (`transport.bufferSize`, raised from Twisted's 64KB default to a configurable 256KB), and
- `resumeProducing()` once that buffer has fully drained.

We can't actually pause the source (broadcasts are pushed from other clients, not pulled), so instead a sustained backlog is treated as a stalled reader: on pause we arm a `reactor.callLater` for the grace period (default 30s); if the buffer drains first, `resumeProducing()` cancels it. Only if the buffer stays backed up for the full grace period is the client disconnected.

A healthy client - including one receiving a large login state-dump (Phase 1.7) - drains in milliseconds, fires `resumeProducing()`, and is never affected.

Two tunables on `DataHandler` (placed next to `pool_size`):
- `write_buffer_highwater = 256 * 1024`
- `write_buffer_grace = 30`

Files: `twistedserver.py` (producer registration + callbacks on the `Chat` protocol), `DataHandler.py` (the two tunables). The producer logic lives on `Chat`, not `Client`, so the internal ChanServ pseudo-client (no real transport) is untouched.

## Verification

Tested locally against a SQLite build (Twisted 26.4.0, Python 3.14, macOS):

- **Deterministic logic test** of the real `Chat` producer callbacks via a fake transport and the real reactor: a sustained pause fires `abortConnection` after the grace period; a pause followed by a resume before grace cancels the timer and does **not** disconnect; repeated `pause()` calls reuse a single timer; timer references are cleared after firing/cancelling. All checks pass.
- **Live multi-client test**: confirmed `registerProducer` is wired and that `pauseProducing`/`resumeProducing` fire on genuinely backed-up real sockets, while a healthy reader that keeps draining is never disconnected, and normal login + channel SAY delivery is unchanged.
- **Boot/login smoke test** on the shipped defaults: server boots and a full REGISTER -> LOGIN -> CONFIRMAGREEMENT -> JOIN handshake works with producer registration active.

Honest caveat on the live test: a full end-to-end socket disconnect could not be forced over **macOS loopback**, because macOS auto-grows the receiver buffer up to `autorcvbufmax` (4MB here) and ignores small `SO_RCVBUF` requests. A "stalled" loopback reader's server-side buffer therefore oscillates (it keeps draining into the growing kernel buffer) instead of staying pinned above the high-water mark, so the sustained-pause state isn't reached until ~4MB is buffered. On a real network with a normal receive window the buffer fills and stays full, triggering the disconnect as designed - which is exactly the path the deterministic logic test exercises.

No protocol or wire-format changes. Branches off current `master`; independent of the still-open Phase 1 DB-caching PR.