### PR TITLE
Broadcast over per-channel client sets, cheaper send stats (OPTIMIZATIONS 2.1)

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -213,12 +213,15 @@ class Client():
 	##
 	## send data to client
 	##
-	def RealSend(self, data):
+	def RealSend(self, data, command=None):
 		if not data:
 			return
 
-		raw_msg  = data[data.find(" ")+1:] if data.startswith('#') else data
-		command = raw_msg[:raw_msg.find(" ")] if " " in raw_msg else raw_msg
+		# 2.1: command may be precomputed by the broadcast path (same token for every
+		# recipient of one message). Only fall back to deriving it per-send otherwise.
+		if command is None:
+			raw_msg  = data[data.find(" ")+1:] if data.startswith('#') else data
+			command = raw_msg[:raw_msg.find(" ")] if " " in raw_msg else raw_msg
 		self._root.outbound_command_stats[command] = self._root.outbound_command_stats.get(command, 0) + 1
 
 		#logging.info("> [" + self.username + " " + str(self.session_id) + "] " + data.strip()) # uncomment for debugging
@@ -232,13 +235,13 @@ class Client():
 		else:
 			self.transport.write(data.encode("utf-8") + b"\n")
 
-	def Send(self, data):
+	def Send(self, data, command=None):
 		if self.msg_id:
 			data = self.msg_id + data
 		if self.buffersend:
 			self.buffer.append(data + "\n")
 		else:
-			self.RealSend(data)
+			self.RealSend(data, command)
 
 	def flushBuffer(self):
 		self.transport.write("".join(self.buffer).encode("utf-8"))

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -633,13 +633,16 @@ class DataHandler:
 		self.decrement_dict(self.recent_renames)
 
 	# the sourceClient is only sent for SAY*, and RING commands
-	def multicast(self, session_ids, msg, ignore=(), sourceClient=None, flag=None, not_flag=None):
+	# 2.1: takes an iterable of client objects directly (channel.user_clients,
+	# battle.user_clients or self.clients.values()) so there is no per-recipient
+	# clientFromSession() lookup. The outbound-stats command token is derived once
+	# here and passed to Send(), instead of RealSend() recomputing it per recipient.
+	def multicast(self, clients, msg, ignore=(), sourceClient=None, flag=None, not_flag=None):
 		assert(type(ignore) == set)
+		raw = msg[msg.find(" ")+1:] if msg.startswith('#') else msg
+		command = raw[:raw.find(" ")] if " " in raw else raw
 		static = []
-		for session_id in session_ids:
-			assert(type(session_id) == int)
-			client = self.clientFromSession(session_id)
-
+		for client in clients:
 			if not client.logged_in:
 				continue
 			if client.session_id in ignore:
@@ -654,21 +657,21 @@ class DataHandler:
 			if client.static:
 				static.append(client)
 			else:
-				client.Send(msg)
+				client.Send(msg, command)
 
 		# this is so static clients don't respond before other people even receive the message
 		for client in static:
-			client.Send(msg)
+			client.Send(msg, command)
 
 	# the sourceClient is only sent for SAY*, and RING commands
 	def broadcast(self, msg, chan=None, ignore=set(), sourceClient=None, flag=None, not_flag=None):
 		assert(type(ignore) == set)
 		try:
 			if not chan in self.channels:
-				self.multicast(self.clients, msg, ignore, sourceClient, flag, not_flag)
+				self.multicast(self.clients.values(), msg, ignore, sourceClient, flag, not_flag)
 				return
 			channel = self.channels[chan]
-			self.multicast(channel.users, msg, ignore, sourceClient, flag, not_flag)
+			self.multicast(channel.user_clients, msg, ignore, sourceClient, flag, not_flag)
 		except:
 			logging.error(traceback.format_exc())
 
@@ -679,7 +682,7 @@ class DataHandler:
 		if not battle_id in self.battles:
 			return
 		battle = self.battles[battle_id]
-		self.multicast(battle.users, msg, ignore, sourceClient, flag, not_flag)
+		self.multicast(battle.user_clients, msg, ignore, sourceClient, flag, not_flag)
 
 	def admin_broadcast(self, msg):
 		for user in self.usernames:

--- a/protocol/Channel.py
+++ b/protocol/Channel.py
@@ -22,6 +22,10 @@ class Channel():
 		# non-db fields
 		self.operators = set() #user_ids
 		self.users = set() # session_ids
+		# 2.1: client objects mirroring self.users, kept in lockstep in addUser/removeUser.
+		# Lets broadcast() iterate this channel's members directly instead of doing a
+		# clientFromSession() dict lookup per recipient per message.
+		self.user_clients = set() # client objects
 		self.bridged_users = set() #bridged_ids
 		
 		self.topic_username = ''
@@ -68,6 +72,7 @@ class Channel():
 		if client.session_id in self.users:
 			return
 		self.users.add(client.session_id)
+		self.user_clients.add(client)
 		client.channels.add(self.name)
 		if not client.static:
 			self.recordUse()
@@ -117,6 +122,7 @@ class Channel():
 		else:
 			self.broadcast('LEFT %s %s' % (self.name, client.username), set(), flag)
 		self.users.remove(client.session_id)
+		self.user_clients.discard(client)
 		if not client.static:
 			self.recordUse()
 


### PR DESCRIPTION
## What

Phase 2, item 2.1 of OPTIMIZATIONS.md: take the per-recipient overhead off the broadcast fan-out path.

Two costs scaled with fan-out:
1. `multicast()` iterated a channel/battle's set of **session_ids** and called `clientFromSession()` - a dict lookup plus a guard - for **every recipient of every message**.
2. `RealSend()` recomputed the outbound-stats command token (`data.find(" ")` x2) once **per recipient**, even though every recipient of one broadcast gets the same command.

## How

`Channel` now keeps a parallel set of **client objects**, `user_clients`, mirroring the existing `users` (session_ids). It is mutated in lockstep in the only two places channel/battle membership ever changes - `Channel.addUser()` and `Channel.removeUser()` - so it stays correct across every join / part / disconnect / kick / host-close / battle-destroy path, all of which route through those two methods (verified by reading every mutation site, including all of `Battle.py`; `Battle` inherits both). `channel.users` is left completely untouched, so ChanServ, the `CLIENTS` user list, and every other reader are unaffected - the new set is used only by the broadcast fast-path.

`multicast()` now takes an iterable of client objects directly:
- `broadcast(chan)` -> `channel.user_clients`
- `broadcast_battle(id)` -> `battle.user_clients`
- global `broadcast()` -> `self.clients.values()`

so there is no per-recipient `clientFromSession()` lookup. Storing the client ref is also slightly safer than the old lookup, which would have `AttributeError`ed on a `None` for a stale session - both old and new code rely on the same invariant (membership never holds a dead session), maintained by the same funnel.

The stats command token is derived **once** per broadcast in `multicast()` and passed through `Send()`/`RealSend()` via a new optional `command` argument (defaults to `None` -> derive as before, so all non-broadcast callers are unchanged). Per-message stat counts are identical to before.

Note: the roadmap framed `multicast` as "O(n) over ALL clients for every channel message". That isn't quite the starting point - it already iterated only the channel's own membership (`channel.users`), so the real win here is removing the per-recipient dict lookup and the repeated stats-token work, not reducing the iteration count. The global-broadcast path is inherently over all clients and stays that way.

Files: `protocol/Channel.py` (the parallel set + its two lockstep mutations), `DataHandler.py` (`multicast`/`broadcast`/`broadcast_battle`), `Client.py` (optional precomputed `command`).

## Verification

Live multi-client test against a SQLite build (Twisted 26.4.0, Python 3.14), 3 clients in one channel, asserting exact recipient counts:

- 3 members, one `SAY` -> each of the 3 receives **exactly one** `SAID` (no duplicates, no misses); sender echo unchanged.
- One member parts (`LEAVE`) -> the leaver receives its own `LEFT` and each remaining member receives exactly one `LEFT` (confirms `user_clients` is removed at the same point as `users`, i.e. after the `LEFT` broadcast).
- After the part, a further `SAY` reaches **only** the remaining members; the parted client receives zero.
- After a member disconnects abruptly (socket closed), a further `SAY` reaches the remaining member with **no stale reference** and **no traceback / invalid-session warning** in the server log.

All assertions passed; server log clean.

Honest scope note on battles: a live battle broadcast was **not** exercised, because hosting a battle requires a TLS connection and my test harness uses plaintext sockets. `broadcast_battle` is covered structurally rather than at runtime: `self.battles[id]` and `self.channels[battle.name]` are the **same** `Battle` object, so `battle.user_clients` is the identical set the verified channel path uses; battle membership funnels through the same tested `addUser`/`removeUser`; and `in_SAYBATTLE` delegates to `in_SAY` on the battle's channel name, i.e. the channel path that is verified above.

No protocol or wire-format change. Branches off current `master`; independent of PR #5 (2.3) and the open Phase 1 DB-caching PR (light overlap in `DataHandler.py`/`Client.py` at merge time).