### PR TITLE
Add a FIFO login queue to absorb login storms (OPTIMIZATIONS 2.2)

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -1,4 +1,5 @@
 import time, sys, os, socket
+import collections
 
 import subprocess
 import traceback
@@ -99,6 +100,13 @@ class DataHandler:
 		self.bridged_locations = {} #location->bridge_user_id
 		self.bridged_ids = {} #bridged_id->bridgedClient
 		self.bridged_usernames = {} #bridgeUsername->bridgedClient
+
+		# 2.2: login queue - smooths login storms (server restart, scheduled events) so
+		# concurrent logins don't all hit the DB at once. Logins beyond login_drain_rate
+		# per second are queued FIFO and drained by drain_login_queue() (a 1s LoopingCall).
+		self.login_queue = collections.deque() # (client, login_args) awaiting login under load
+		self.login_drain_rate = 10             # max logins processed per second
+		self.logins_this_second = 0            # budget shared by inline + drained logins; reset each second
 
 		# rate limits
 		self.nonres_registrations = set() #user_id
@@ -626,6 +634,26 @@ class DataHandler:
 		finally:
 			self.session_manager.close_guard()
 	
+	def drain_login_queue(self):
+		# 2.2: reset the per-second login budget, then process queued logins up to the
+		# drain rate. Runs on the reactor thread (1s LoopingCall) so it shares login_queue
+		# / logins_this_second with in_LOGIN without locking. Each login gets its own
+		# session commit/rollback/close, mirroring the per-request guards in dataReceived.
+		self.logins_this_second = 0
+		while self.login_queue and self.logins_this_second < self.login_drain_rate:
+			client, args = self.login_queue.popleft()
+			if client.session_id not in self.clients:
+				continue # client disconnected while queued
+			self.logins_this_second += 1
+			try:
+				self.protocol.in_LOGIN_now(client, *args)
+				self.session_manager.commit_guard()
+			except:
+				logging.error(traceback.format_exc())
+				self.session_manager.rollback_guard()
+			finally:
+				self.session_manager.close_guard()
+
 	def decrement_recent_registrations(self):
 		self.decrement_dict(self.recent_registrations)
 

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -965,6 +965,21 @@ class Protocol:
 
 	def in_LOGIN(self, client, username, password, cpu='0', local_ip='', sentence_args=''):
 		'''
+		2.2: login-queue gate. Under a login storm, defer this login into a FIFO queue
+		drained at _root.login_drain_rate/sec by DataHandler.drain_login_queue(), and tell
+		the client it is queued. Otherwise spend a slot from the per-second budget and log
+		in immediately. The actual work lives in in_LOGIN_now(); this wrapper keeps the same
+		signature so command dispatch (which reflects on the signature) is unchanged.
+		'''
+		if self._root.login_queue or self._root.logins_this_second >= self._root.login_drain_rate:
+			self._root.login_queue.append((client, (username, password, cpu, local_ip, sentence_args)))
+			client.Send('SERVERMSG The server is busy; you are number %d in the login queue, please wait...' % len(self._root.login_queue))
+			return
+		self._root.logins_this_second += 1
+		self.in_LOGIN_now(client, username, password, cpu, local_ip, sentence_args)
+
+	def in_LOGIN_now(self, client, username, password, cpu='0', local_ip='', sentence_args=''):
+		'''
 		Attempt to login the active client.
 
 		@required.str username: Username

--- a/server.py
+++ b/server.py
@@ -61,6 +61,8 @@ try:
 	
 	event_loop = task.LoopingCall(_root.channel_mute_ban_timeout)
 	event_loop.start(1)
+	login_queue_loop = task.LoopingCall(_root.drain_login_queue)
+	login_queue_loop.start(1)
 	recent_registration_loop = task.LoopingCall(_root.decrement_recent_registrations)
 	recent_registration_loop.start(60*20)
 	recent_rename_loop = task.LoopingCall(_root.decrement_recent_renames)


### PR DESCRIPTION
## What

Phase 2, item 2.2 of OPTIMIZATIONS.md: turn a login storm from a hard failure mode into graceful queuing.

When many users connect simultaneously (server restart, scheduled event) the login handler hits the DB with many concurrent, blocking requests on the single reactor thread, causing cascading slowdowns. A simple FIFO queue with a fixed drain rate spreads that work over time.

## How

`in_LOGIN` becomes a thin gate:
- If logins processed this second are under `login_drain_rate` (default 10/s) **and** there is no backlog, it logs the client in **inline**, exactly as before (zero added latency in the common, no-storm case).
- Otherwise it appends `(client, args)` to a FIFO `login_queue` and sends the client a `SERVERMSG` with its queue position.

A 1-second `LoopingCall`, `drain_login_queue()`, resets the per-second budget and processes up to `login_drain_rate` queued logins per tick. It skips any client that disconnected while queued, and wraps each login in its own session `commit`/`rollback`/`close` guard (the drainer runs outside `dataReceived`'s per-request guards).

The actual login work is unchanged: the original `in_LOGIN` body is renamed to `in_LOGIN_now()`, and the new `in_LOGIN` wrapper keeps the **identical signature** so command dispatch - which reflects on the handler signature to split arguments - is completely unaffected. (A bypass *parameter* was deliberately avoided: it would change the arg count and corrupt argument splitting for lobby agent strings containing spaces.)

A single per-second budget (`logins_this_second`) is shared by both the inline and the drained paths, so under load the backlog is always served before newly-arriving logins (true FIFO). `login_drain_rate` is tunable on `DataHandler`. Everything runs on the reactor thread, so the queue needs no locking.

Files: `protocol/Protocol.py` (the gate + rename), `DataHandler.py` (queue state + drainer), `server.py` (registers the `LoopingCall` alongside the existing ones).

## Verification

Tested locally against a SQLite build (Twisted 26.4.0, Python 3.14) with `login_drain_rate` temporarily set to 3 to make queuing observable (same code path, only the constant differs; restored to 10 for the commit):

- 9 accounts registered, then all 9 `LOGIN`s blasted within one budget window.
- **All 9 logins completed** (each received its `AGREEMENT` response) - none lost.
- **6 of 9 received the queue `SERVERMSG`** (9 minus the drain rate of 3).
- Completion timing confirmed FIFO draining at exactly the rate: 3 inline at ~0.0s, 3 at ~0.1s (first drain tick), 3 at ~1.1s (next tick).
- Server log clean, no tracebacks.
- Separately, on the shipped `login_drain_rate=10`, a normal single login is instant and the full `REGISTER` -> `LOGIN` -> `CONFIRMAGREEMENT` -> `JOIN` handshake works unchanged.

Known limitation (graceful by design): a freshly connected client has the existing 60s connection timeout and hasn't authenticated yet, so if the queue is deeper than roughly `login_drain_rate * 60` the tail will time out and disconnect rather than wait indefinitely - which is the intended shedding behaviour under an extreme storm.

Uses the existing `SERVERMSG` type - no protocol or wire-format change. Branches off current `master`; independent of PR #5 (2.3) and PR #6 (2.1), with light overlap in `DataHandler.py`.