### PR TITLE
Make the SQLAlchemy session thread-local and wire the DB thread pool (OPTIMIZATIONS 3.1)

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -72,6 +72,12 @@ class DataHandler:
 
 		self.pool_size = 50
 
+		# 3.1: max concurrent off-reactor DB worker threads (deferToThread thread pool).
+		# Each worker needs its own DB connection, so this is clamped to pool_size below.
+		# Forced to 1 for sqlite (which cannot do real concurrency). Default matches
+		# Twisted's own default reactor thread pool size.
+		self.max_threads = 10
+
 		# 2.3: bound per-client write buffers (slow-loris / stalled-reader DoS guard).
 		# transport.write() queues unsent data in memory with no bound, so a client
 		# that stops reading lets its server-side buffer grow without limit. We register
@@ -163,6 +169,10 @@ class DataHandler:
 			from sqlalchemy import event
 			event.listen(self.engine, 'connect', _fk_pragma_on_connect)
 		else:
+			# 3.1: each DB worker thread holds its own pooled connection, so never run
+			# more workers than the pool can serve.
+			if self.max_threads > self.pool_size:
+				self.max_threads = self.pool_size
 			self.engine = sqlalchemy.create_engine(self.sqlurl, pool_size=self.pool_size, pool_recycle=3600)
 
 		self.session_manager = SQLUsers.session_manager(self, self.engine)

--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -14,7 +14,7 @@ import _thread as thread
 	
 try:
 	from sqlalchemy import create_engine, Table, Column, Integer, String, MetaData, ForeignKey, Boolean, Text, DateTime, ForeignKeyConstraint, UniqueConstraint
-	from sqlalchemy.orm import mapper, sessionmaker, relation
+	from sqlalchemy.orm import mapper, sessionmaker, relation, scoped_session
 	from sqlalchemy.exc import IntegrityError
 except ImportError as e:
 	print("ERROR: sqlalchemy isn't installed: " + str(e))
@@ -428,29 +428,32 @@ mapper(MinSpringVersion, min_spring_version_table)
 ##########################################
 
 class session_manager():
-	# on-demand sessionmaker
+	# on-demand, thread-local sessionmaker (Phase 3.1).
+	# scoped_session gives each thread its own Session keyed by thread id, so DB work
+	# run off the reactor thread via deferToThread cannot share a Session (which is not
+	# thread-safe). On the single reactor thread this is behaviourally identical to the
+	# previous single-shared-session model: lazily created, committed/closed per request
+	# by the guards below (called from dataReceived / the LoopingCalls).
 	def __init__(self, root, engine):
 		self._root = root
 		metadata.create_all(engine)
-		self.sessionmaker = sessionmaker(bind=engine, autoflush=True)
-		self.session = None
-	
+		self.sessionmaker = scoped_session(sessionmaker(bind=engine, autoflush=True))
+
 	def sess(self):
-		if not self.session:
-			self.session = self.sessionmaker()
-		return self.session
-		
-	# guarded access
+		# returns this thread's session, creating it on first use
+		return self.sessionmaker()
+
+	# guarded access. registry.has() keeps the old "don't create a session just to
+	# commit nothing" no-op semantics; these only ever touch the calling thread's session.
 	def commit_guard(self):
-		if self.session:
-			self.session.commit()
+		if self.sessionmaker.registry.has():
+			self.sessionmaker.commit()
 	def rollback_guard(self):
-		if self.session:
-			self.session.rollback()
+		if self.sessionmaker.registry.has():
+			self.sessionmaker.rollback()
 	def close_guard(self):
-		if self.session:
-			self.session.close()
-			self.session = None
+		if self.sessionmaker.registry.has():
+			self.sessionmaker.remove()
 
 ##########################################
 			

--- a/server.py
+++ b/server.py
@@ -67,7 +67,10 @@ try:
 	recent_registration_loop.start(60*20)
 	recent_rename_loop = task.LoopingCall(_root.decrement_recent_renames)
 	recent_rename_loop.start(60*60*24*7)
-	
+
+	# 3.1: size the reactor thread pool for off-reactor DB work (deferToThread).
+	reactor.suggestThreadPoolSize(_root.max_threads)
+
 	reactor.run()
 
 except KeyboardInterrupt:


### PR DESCRIPTION
Phase 3 (async DB) infrastructure. **No runtime behaviour change** — this lays the groundwork so DB calls can later run off the reactor thread via `deferToThread`, and is the first of an incremental sequence of small PRs for Phase 3.

## Why
The whole server is currently correct only because everything runs on the single reactor thread. The central blocker for async DB is that `session_manager` hands out **one shared** `Session`, and a SQLAlchemy `Session` is not thread-safe. This PR removes that blocker without changing behaviour.

## Changes
- **`session_manager` -> `scoped_session`** (SQLUsers.py). Each thread (the reactor thread today, future `deferToThread` workers tomorrow) transparently gets its own thread-local `Session`. The commit/rollback/close guards keep their "don't create a session just to commit nothing" semantics via `registry.has()`, and `close_guard` uses `.remove()`. On the single reactor thread this is behaviourally identical to the previous single-shared-session model.
- **`max_threads` is now a real setting** (DataHandler.py): default 10 (matches Twisted's default reactor pool), forced to 1 for sqlite, and clamped to `pool_size` so DB workers never outnumber available pooled connections.
- **Reactor thread pool sizing** (server.py): `reactor.suggestThreadPoolSize(max_threads)` before `reactor.run()`. Dormant until the first `deferToThread` conversion.

## Testing
Booted against a real **MariaDB 12.3.2** (sqlite cannot exercise threading: it forces `max_threads=1`, no pool, `check_same_thread`). Verified:
- Server starts, creates all tables, ChanServ logs in.
- All startup `LoopingCall` DB operations (scheduled_clean, audit_access, clean) run through the new `scoped_session` guards with no errors.
- Full REGISTER -> LOGIN -> CONFIRMAGREEMENT flow succeeds (ACCEPTED + full state dump); the user and login row persist correctly.

This PR wires threading but does **not** use it yet, so the off-reactor path is intentionally not exercised here — that lands in the follow-up PR that converts `in_LOGIN_now` to `deferToThread`.

## Follow-ups (Phase 3)
- PR B: convert `in_LOGIN_now` DB calls to `deferToThread` (worker returns plain data; reactor callback mutates shared state and re-checks login uniqueness).
- Then one PR per remaining handler group.