### PR TITLE
Fix get_account_access referencing a non-existent self.session attribute

### DIFF
--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -725,7 +725,7 @@ class UsersHandler:
 		else: return False, 'User not found in database'
 
 	def get_account_access(self, username):
-		entry = self.session.query(User).filter(User.username==username).first()
+		entry = self.sess().query(User).filter(User.username==username).first()
 		if entry:
 			return True, entry.access
 		else: return False, 'User not found in database'


### PR DESCRIPTION
`UsersHandler.get_account_access` reads `self.session.query(...)`, but `UsersHandler` has no `.session` attribute — every other method in the class goes through `self.sess()` (which returns the session_manager's session). As written, `get_account_access` would raise `AttributeError` the moment it is called.

It currently has no callers in the codebase, so this is a latent bug rather than an active crash, but the one-line fix aligns it with the rest of the class so it works if/when it is used.

Independent of the Phase 3 async-DB work; sent as its own small PR.