### PR TITLE
Run the LOGIN DB calls off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -72,6 +72,12 @@ class DataHandler:
 
 		self.pool_size = 50
 
+		# 3.1: max concurrent off-reactor DB worker threads (deferToThread thread pool).
+		# Each worker needs its own DB connection, so this is clamped to pool_size below.
+		# Forced to 1 for sqlite (which cannot do real concurrency). Default matches
+		# Twisted's own default reactor thread pool size.
+		self.max_threads = 10
+
 		# 2.3: bound per-client write buffers (slow-loris / stalled-reader DoS guard).
 		# transport.write() queues unsent data in memory with no bound, so a client
 		# that stops reading lets its server-side buffer grow without limit. We register
@@ -163,6 +169,10 @@ class DataHandler:
 			from sqlalchemy import event
 			event.listen(self.engine, 'connect', _fk_pragma_on_connect)
 		else:
+			# 3.1: each DB worker thread holds its own pooled connection, so never run
+			# more workers than the pool can serve.
+			if self.max_threads > self.pool_size:
+				self.max_threads = self.pool_size
 			self.engine = sqlalchemy.create_engine(self.sqlurl, pool_size=self.pool_size, pool_recycle=3600)
 
 		self.session_manager = SQLUsers.session_manager(self, self.engine)

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -14,6 +14,7 @@ from protocol import Protocol, Channel, Battle
 import logging
 from logging.handlers import TimedRotatingFileHandler
 from twisted.internet import ssl
+from twisted.internet.threads import deferToThread
 
 separator = '-'*60
 
@@ -684,6 +685,45 @@ class DataHandler:
 			except:
 				logging.error(traceback.format_exc())
 				self.session_manager.rollback_guard()
+			finally:
+				self.session_manager.close_guard()
+
+	def defer_db(self, fn, *args):
+		# 3.1: run a synchronous DB function in the reactor thread pool so it does not
+		# block the event loop. The returned Deferred fires its callbacks back on the
+		# reactor thread (Twisted guarantees this), so callbacks may safely mutate shared
+		# state; fn itself runs on a worker thread and must do PURE DB I/O returning plain
+		# data (no shared-dict mutation, no live ORM rows handed back).
+		return deferToThread(self._run_db, fn, args)
+
+	# transient InnoDB/MariaDB errors that mean "the transaction lost a race; just retry":
+	# 1213 deadlock, 1205 lock-wait timeout, 1020 record-changed-since-last-read. These
+	# only arise when two transactions touch the same row concurrently (e.g. the same user
+	# logging in on two connections at once) - distinct rows never contend.
+	_db_retry_errnos = (1213, 1205, 1020)
+	_db_max_attempts = 4
+
+	def _run_db(self, fn, args):
+		# runs on a worker thread. scoped_session gives this thread its own Session, so we
+		# own its commit/close here (the dataReceived guards only cover the reactor thread).
+		# Retries the whole unit on transient serialization errors; each attempt starts from
+		# a fresh session (close_guard removes the thread-local one), so fn re-reads the row.
+		for attempt in range(self._db_max_attempts):
+			try:
+				result = fn(*args)
+				self.session_manager.commit_guard()
+				return result
+			except Exception as e:
+				self.session_manager.rollback_guard()
+				errno = None
+				orig = getattr(e, 'orig', None)
+				if orig is not None and getattr(orig, 'args', None):
+					errno = orig.args[0]
+				if errno in self._db_retry_errnos and attempt < self._db_max_attempts - 1:
+					self.session_manager.close_guard()
+					time.sleep(0.01 * (attempt + 1))
+					continue
+				raise
 			finally:
 				self.session_manager.close_guard()
 

--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -597,6 +597,45 @@ class UsersHandler:
 		self.invalidate_user_cache(uid, uname)
 		return dbuser
 
+	# --- 3.1 async-login workers -------------------------------------------------
+	# precheck_login and do_login run on a deferToThread worker thread. They do PURE
+	# DB I/O and return plain data (tuples / an OfflineClient snapshot) so the reactor
+	# callback never touches an ORM row bound to the worker's session. They must NOT
+	# mutate shared in-memory state (incl. the user cache) - the reactor callback does
+	# that.
+
+	def precheck_login(self, username, password, ip):
+		# auth + ban check, mirroring the in_LOGIN_now order: check_login_user first,
+		# and only check the ban if the credentials are valid (matching the original
+		# control flow, where a failed credential check returns before the ban query).
+		# Returns plain values; the live User row from check_banned stays in this thread.
+		login_ok, login_reason = self.check_login_user(username, password)
+		banned, ban_reason = False, ""
+		if login_ok:
+			banned, ban_reason, _dbuser = self.check_banned(username, ip)
+		return login_ok, login_reason, banned, ban_reason
+
+	def do_login(self, username, ip, agent, last_sys_id, last_mac_id, local_ip, country):
+		# write the login: re-load the user (the precheck row belonged to another
+		# thread/session and cannot cross threads), update last_* fields, append the
+		# Login record, commit, and return a plain OfflineClient snapshot. Returns None
+		# if the user vanished (rename/delete) between precheck and here. Cache
+		# invalidation is left to the reactor callback (shared-state mutation).
+		dbuser = self.sess().query(User).filter(User.username == username).first()
+		if not dbuser:
+			return None
+		now = datetime.now()
+		dbuser.logins.append(Login(now, dbuser.id, ip, agent, last_sys_id, last_mac_id, local_ip, country))
+		dbuser.last_ip = ip
+		dbuser.last_agent = agent
+		dbuser.last_sys_id = last_sys_id
+		dbuser.last_mac_id = last_mac_id
+		dbuser.last_login = now
+		# snapshot while the row is attached and current, before commit expires it
+		snapshot = OfflineClient(dbuser)
+		self.sess().commit()
+		return snapshot
+
 	def set_user_password(self, username, password):
 		dbuser = self.sess().query(User).filter(User.username==username).first()
 		dbuser.password = password
@@ -1003,6 +1042,11 @@ class BansHandler:
 		# CachedBan snapshot (or None) with a short TTL, so a newly-issued ban still
 		# takes effect within the TTL even if no flush reached us, and every ban
 		# add/remove flushes the cache immediately for instant effect.
+		# 3.1: since login moved off the reactor thread, check_ban (and so this dict) is
+		# now also read/written from deferToThread worker threads. No lock is used: dict
+		# get/set are atomic under the GIL (as the codebase already relies on elsewhere,
+		# e.g. nonres_registrations), and the cache is explicitly staleness-tolerant, so a
+		# racing flush/write only costs a redundant query or a sub-TTL stale entry.
 		self._ban_cache_ttl = 300  # seconds
 		self._ban_cache = {}       # (user_id, ip, email) -> (CachedBan|None, expiry)
 

--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -14,7 +14,7 @@ import _thread as thread
 	
 try:
 	from sqlalchemy import create_engine, Table, Column, Integer, String, MetaData, ForeignKey, Boolean, Text, DateTime, ForeignKeyConstraint, UniqueConstraint
-	from sqlalchemy.orm import mapper, sessionmaker, relation
+	from sqlalchemy.orm import mapper, sessionmaker, relation, scoped_session
 	from sqlalchemy.exc import IntegrityError
 except ImportError as e:
 	print("ERROR: sqlalchemy isn't installed: " + str(e))
@@ -428,29 +428,32 @@ mapper(MinSpringVersion, min_spring_version_table)
 ##########################################
 
 class session_manager():
-	# on-demand sessionmaker
+	# on-demand, thread-local sessionmaker (Phase 3.1).
+	# scoped_session gives each thread its own Session keyed by thread id, so DB work
+	# run off the reactor thread via deferToThread cannot share a Session (which is not
+	# thread-safe). On the single reactor thread this is behaviourally identical to the
+	# previous single-shared-session model: lazily created, committed/closed per request
+	# by the guards below (called from dataReceived / the LoopingCalls).
 	def __init__(self, root, engine):
 		self._root = root
 		metadata.create_all(engine)
-		self.sessionmaker = sessionmaker(bind=engine, autoflush=True)
-		self.session = None
-	
+		self.sessionmaker = scoped_session(sessionmaker(bind=engine, autoflush=True))
+
 	def sess(self):
-		if not self.session:
-			self.session = self.sessionmaker()
-		return self.session
-		
-	# guarded access
+		# returns this thread's session, creating it on first use
+		return self.sessionmaker()
+
+	# guarded access. registry.has() keeps the old "don't create a session just to
+	# commit nothing" no-op semantics; these only ever touch the calling thread's session.
 	def commit_guard(self):
-		if self.session:
-			self.session.commit()
+		if self.sessionmaker.registry.has():
+			self.sessionmaker.commit()
 	def rollback_guard(self):
-		if self.session:
-			self.session.rollback()
+		if self.sessionmaker.registry.has():
+			self.sessionmaker.rollback()
 	def close_guard(self):
-		if self.session:
-			self.session.close()
-			self.session = None
+		if self.sessionmaker.registry.has():
+			self.sessionmaker.remove()
 
 ##########################################
 			

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -1010,22 +1010,33 @@ class Protocol:
 			self.out_DENIED(client, username, "Invalid username: '%s'" % username)
 			return
 
-		good, reason = self.userdb.check_login_user(username, password)
-		if not good:
-			self.out_DENIED(client, username, reason)
+		# 3.1: run the auth + ban check off the reactor thread, then continue in
+		# _login_checked once the DB worker returns. The remaining memory-only checks and
+		# the denial ordering are applied in the callback, preserving the original flow.
+		d = self._root.defer_db(self.userdb.precheck_login, username, password, client.ip_address)
+		d.addCallback(self._login_checked, client, username, local_ip, sentence_args)
+		d.addErrback(self._login_failed, client, username)
+
+	def _login_checked(self, result, client, username, local_ip, sentence_args):
+		# reactor-thread callback after precheck_login (result is plain data). Applies the
+		# same denial ordering as the original linear flow, then defers the login write.
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB call
+		login_ok, login_reason, banned, ban_reason = result
+		if not login_ok:
+			self.out_DENIED(client, username, login_reason)
 			return
-		
+
 		delay, reason = self._check_delayed_registration(client)
 		if delay:
 			self.out_DENIED(client, username, reason)
 			return
- 		
-		banned, reason, dbuser = self.userdb.check_banned(username, client.ip_address)
+
 		if banned:
-			assert (type(reason) == str)
-			self.out_DENIED(client, username, reason)
+			assert (type(ban_reason) == str)
+			self.out_DENIED(client, username, ban_reason)
 			return
-			
+
 		if self.SayHooks.isNasty(sentence_args):
 			self.out_DENIED(client, username, "Invalid sentence args")
 			return
@@ -1037,18 +1048,46 @@ class Protocol:
 			logging.warning("Invalid login sentence '%s' from <%s>" % (sentence_args, username))
 			self.out_DENIED(client, username, 'Invalid sentence format, please update your lobby client.')
 			return
-		else: 
+		else:
 			agent, last_id, compat_flags = sentence_args.split('\t',2)
 			if " " in last_id:
-				last_mac_id, last_sys_id = last_id.split(" ") 
+				last_mac_id, last_sys_id = last_id.split(" ")
 			else:
-				last_mac_id = last_id 
+				last_mac_id = last_id
 				last_sys_id = "0" # backwards compat for SL<0.269
 			for flag in compat_flags.split(' '):
 				client.compat.add(flag)
-		
-		# login checks complete
-		dbuser = self.userdb.login_user(dbuser, client.ip_address, agent, last_sys_id, last_mac_id, local_ip, client.country_code)
+
+		# login checks complete; write the login record off the reactor thread.
+		d = self._root.defer_db(self.userdb.do_login, username, client.ip_address, agent, last_sys_id, last_mac_id, local_ip, client.country_code)
+		d.addCallback(self._login_finish, client, username, agent, local_ip)
+		d.addErrback(self._login_failed, client, username)
+
+	def _login_finish(self, dbuser, client, username, agent, local_ip):
+		# reactor-thread callback after do_login. dbuser is a plain OfflineClient snapshot,
+		# or None if the account vanished between the auth check and the write.
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB call
+		if dbuser is None:
+			self.out_DENIED(client, username, 'Invalid username or password')
+			return
+		# This callback runs outside dataReceived's per-request session guard, but the
+		# work below can still touch the DB on the reactor thread (_SendLoginInfo's
+		# get_ignored_user_ids, and the moderator in_JOIN). Bracket it the same way
+		# dataReceived does so the reactor session is committed/closed and never leaks.
+		try:
+			self._login_finish_now(dbuser, client, username, agent, local_ip)
+			self._root.session_manager.commit_guard()
+		except:
+			logging.error(traceback.format_exc())
+			self._root.session_manager.rollback_guard()
+		finally:
+			self._root.session_manager.close_guard()
+
+	def _login_finish_now(self, dbuser, client, username, agent, local_ip):
+		# invalidate the offline-user cache here, on the reactor thread (the worker must
+		# not mutate shared state)
+		self.userdb.invalidate_user_cache(dbuser.id, dbuser.username)
 
 		# update local client fields from DB User values
 		client.access = dbuser.access
@@ -1066,7 +1105,7 @@ class Protocol:
 		client.ingame_time = dbuser.ingame_time
 		client.email = dbuser.email
 		client.agent = agent
-	
+
 		if (client.access == 'agreement'):
 			logging.info('[%s] Sent user <%s> the terms of service on session.' % (client.session_id, dbuser.username))
 			if self.verificationdb.active():
@@ -1076,24 +1115,31 @@ class Protocol:
 				client.Send("AGREEMENT %s" %(line))
 			client.Send('AGREEMENTEND')
 			return
-		
+
 		client.local_ip = local_ip
 		if local_ip.startswith('127.') or not self._validateIP(local_ip):
 			client.local_ip = client.ip_address
 
 		if client.ip_address in self._root.trusted_proxies:
 			client.setFlagByIP(local_ip, False)
-	
-		try:
-			assert(username == client.username)
-			assert(not client.user_id in self._root.user_ids)
-			assert(not client.username in self._root.usernames)
-		except Exception as e:
-			logging.error("Exception from LOGIN asserts: %s %s %d" % (username, client.username, client.user_id))
-			logging.error(traceback.format_exc())
-		
+
+		# re-check uniqueness now: usernames/user_ids may have changed during the async DB
+		# hops. This is the atomicity guarantee against two concurrent logins of the same
+		# account - it runs on the reactor thread, so no lock is needed. (The original code
+		# only asserted-and-logged here; we now actually reject the duplicate.)
+		if client.username in self._root.usernames or client.user_id in self._root.user_ids:
+			self.out_DENIED(client, username, 'Already logged in.')
+			return
+
 		self._root.client_LoginStats(client)
 		self._SendLoginInfo(client)
+
+	def _login_failed(self, failure, client, username):
+		# reactor-thread errback: a DB error during login. Log it and tell the client
+		# rather than leaving the connection hanging.
+		logging.error("LOGIN DB error for <%s>: %s" % (username, failure.getTraceback()))
+		if client.session_id in self._root.clients:
+			self.out_DENIED(client, username, 'Login failed due to a server error, please try again.')
 
 	def _SendLoginInfo(self, client):
 		self._calc_status(client, 0)

--- a/server.py
+++ b/server.py
@@ -67,7 +67,10 @@ try:
 	recent_registration_loop.start(60*20)
 	recent_rename_loop = task.LoopingCall(_root.decrement_recent_renames)
 	recent_rename_loop.start(60*60*24*7)
-	
+
+	# 3.1: size the reactor thread pool for off-reactor DB work (deferToThread).
+	reactor.suggestThreadPoolSize(_root.max_threads)
+
 	reactor.run()
 
 except KeyboardInterrupt:


### PR DESCRIPTION
Phase 3, step B: make the login flow's blocking DB work asynchronous so a slow login query no longer stalls every other connected client.

> **Stacked on #8** (`perf/phase3-async-db-infra`, the thread-local `session_manager` + thread-pool wiring). Until #8 merges, this PR's diff includes #8's commit — review the commit titled *"Run the LOGIN DB calls off the reactor thread..."* in isolation, and merge after #8.

## What changes
Converts `in_LOGIN_now`'s three blocking DB calls (`check_login_user`, `check_banned`, `login_user`) to run in the reactor thread pool via `deferToThread`. The split keeps workers pure (DB I/O returning plain data) and does all shared-state mutation + sends in reactor-thread Deferred callbacks:

- **`precheck_login`** (worker): auth + ban check -> plain tuple.
- **`_login_checked`** (reactor): applies the original denial ordering (credentials -> delayed-registration -> ban -> sentence parsing), then defers the write.
- **`do_login`** (worker): re-loads the user, writes `last_*` + the `Login` record, commits, returns an `OfflineClient` snapshot. No live ORM row ever crosses threads.
- **`_login_finish`** (reactor): copies fields onto the client, runs the agreement branch or `_SendLoginInfo`, bracketed with the session guards exactly like `dataReceived` (it runs outside that per-request bracket).
- **`_login_failed`** (reactor errback): logs and sends `DENIED` rather than leaving the client hanging on a DB error.

## Concurrency
- **Uniqueness:** two simultaneous logins of the same account can both pass the entry check, so `_login_finish` re-checks `usernames`/`user_ids` on the reactor thread right before inserting. Reactor callbacks are serialized, so no lock is needed — exactly one wins, the rest get `Already logged in`. (The old code only asserted-and-logged here.)
- **Serialization failures:** concurrent writes to the *same* row can raise transient errors (deadlock 1213, lock-wait 1205, record-changed 1020). `_run_db` retries the unit a few times from a fresh session. Distinct rows never contend.
- **Ban cache (1.1):** now read/written from worker threads; documented as safe via GIL-atomic dict ops (consistent with existing code like `nonres_registrations`) plus the cache's existing staleness tolerance. No lock added.

## Scope
Only the three login-path DB calls are converted. `_SendLoginInfo`'s `get_ignored_user_ids` stays synchronous for now because `_SendLoginInfo` is shared with `CONFIRMAGREEMENT`; the reactor-side session bracket keeps it correct. Other handlers will be converted one group at a time in later PRs.

## Testing
Against **MariaDB 12.3.2 (InnoDB)** — sqlite can't exercise this (it forces `max_threads=1`):
- Register -> login -> confirm-agreement flow works.
- **30 concurrent distinct logins**: all 30 succeed, no errors.
- **6 simultaneous same-user logins**: exactly **1 winner, 5 clean `Already logged in` denials**, zero DB errors/tracebacks (the retry absorbs the transient serialization errors).

Not benchmarked: a true "slow query doesn't block the reactor" latency test (would need query-latency injection); correctness and concurrency-safety are verified, raw throughput improvement is not yet measured.