### PR TITLE
Run the social list reads off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -1610,15 +1610,39 @@ class Protocol:
 		client.Send('UNIGNORE userName=%s' % (username))
 
 	def in_IGNORELIST(self, client):
-		client.Send('IGNORELISTBEGIN')
-		for (userId, reason) in self.userdb.get_ignore_list(client.user_id):
-			ignoredClient = self.clientFromID(userId, True)
-			username = ignoredClient.username
-			if reason:
-				client.Send('IGNORELIST userName=%s\treason=%s' % (username, reason))
-			else:
-				client.Send('IGNORELIST userName=%s' % (username))
-		client.Send('IGNORELISTEND')
+		# 3.1: read the ignore list off the reactor thread, then format + send in
+		# _ignorelist_send once the worker returns plain [(ignored_user_id, reason), ...].
+		d = self._root.defer_db(self.userdb.get_ignore_list, client.user_id)
+		d.addCallback(self._ignorelist_send, client)
+		d.addErrback(self._social_list_failed, client, "IGNORELIST")
+
+	def _ignorelist_send(self, entries, client):
+		# reactor-thread callback. clientFromID may do a reactor-side DB read on an
+		# offline-cache miss, so bracket the reactor session like _login_finish does.
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB call
+		try:
+			client.Send('IGNORELISTBEGIN')
+			for (userId, reason) in entries:
+				ignoredClient = self.clientFromID(userId, True)
+				username = ignoredClient.username
+				if reason:
+					client.Send('IGNORELIST userName=%s\treason=%s' % (username, reason))
+				else:
+					client.Send('IGNORELIST userName=%s' % (username))
+			client.Send('IGNORELISTEND')
+			self._root.session_manager.commit_guard()
+		except:
+			logging.error(traceback.format_exc())
+			self._root.session_manager.rollback_guard()
+		finally:
+			self._root.session_manager.close_guard()
+
+	def _social_list_failed(self, failure, client, cmd):
+		# reactor-thread errback shared by the social list reads: a DB error fetching the
+		# list. Log it loudly; these commands have no protocol-level failure reply, so the
+		# client simply receives no list (equivalent to an empty result).
+		logging.error("%s DB error for <%s>: %s" % (cmd, getattr(client, 'username', '?'), failure.getTraceback()))
 
 	# FIXME: there is currently no limit to the number of friend requests one user can send
 	def in_FRIENDREQUEST(self, client, tags):
@@ -1706,23 +1730,55 @@ class Protocol:
 			friendRequestClient.Send('UNFRIEND userName=%s' % client.username)
 
 	def in_FRIENDREQUESTLIST(self, client):
-		client.Send('FRIENDREQUESTLISTBEGIN')
-		for (userId, msg) in self.userdb.get_friend_request_list(client.user_id):
-			friendRequestClient = self.clientFromID(userId, True)
-			username = friendRequestClient.username
-			if msg:
-				client.Send('FRIENDREQUESTLIST userName=%s\tmsg=%s' % (username, msg))
-			else:
-				client.Send('FRIENDREQUESTLIST userName=%s' % (username))
-		client.Send('FRIENDREQUESTLISTEND')
+		# 3.1: read off the reactor thread; worker returns plain [(user_id, msg), ...].
+		d = self._root.defer_db(self.userdb.get_friend_request_list, client.user_id)
+		d.addCallback(self._friendrequestlist_send, client)
+		d.addErrback(self._social_list_failed, client, "FRIENDREQUESTLIST")
+
+	def _friendrequestlist_send(self, entries, client):
+		# reactor-thread callback; bracket the session because clientFromID may read the DB.
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB call
+		try:
+			client.Send('FRIENDREQUESTLISTBEGIN')
+			for (userId, msg) in entries:
+				friendRequestClient = self.clientFromID(userId, True)
+				username = friendRequestClient.username
+				if msg:
+					client.Send('FRIENDREQUESTLIST userName=%s\tmsg=%s' % (username, msg))
+				else:
+					client.Send('FRIENDREQUESTLIST userName=%s' % (username))
+			client.Send('FRIENDREQUESTLISTEND')
+			self._root.session_manager.commit_guard()
+		except:
+			logging.error(traceback.format_exc())
+			self._root.session_manager.rollback_guard()
+		finally:
+			self._root.session_manager.close_guard()
 
 	def in_FRIENDLIST(self, client):
-		client.Send('FRIENDLISTBEGIN')
-		for userId in self.userdb.get_friend_user_ids(client.user_id):
-			friendClient = self.clientFromID(userId, True)
-			username = friendClient.username
-			client.Send('FRIENDLIST userName=%s' % (username))
-		client.Send('FRIENDLISTEND')
+		# 3.1: read off the reactor thread; worker returns plain [user_id, ...].
+		d = self._root.defer_db(self.userdb.get_friend_user_ids, client.user_id)
+		d.addCallback(self._friendlist_send, client)
+		d.addErrback(self._social_list_failed, client, "FRIENDLIST")
+
+	def _friendlist_send(self, userIds, client):
+		# reactor-thread callback; bracket the session because clientFromID may read the DB.
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB call
+		try:
+			client.Send('FRIENDLISTBEGIN')
+			for userId in userIds:
+				friendClient = self.clientFromID(userId, True)
+				username = friendClient.username
+				client.Send('FRIENDLIST userName=%s' % (username))
+			client.Send('FRIENDLISTEND')
+			self._root.session_manager.commit_guard()
+		except:
+			logging.error(traceback.format_exc())
+			self._root.session_manager.rollback_guard()
+		finally:
+			self._root.session_manager.close_guard()
 
 
 	def in_JOIN(self, client, chan, key=None):


### PR DESCRIPTION
Part of OPTIMIZATIONS.md Phase 3.1 (async database). Follows the LOGIN conversion (PR #10), reusing the same `defer_db`/`_run_db` infra from PR #8.

## What changes
Converts the three social list-read handlers from blocking reactor-thread DB reads to the established async pattern:

- `in_IGNORELIST` -> `get_ignore_list` worker + `_ignorelist_send` callback
- `in_FRIENDLIST` -> `get_friend_user_ids` worker + `_friendlist_send` callback
- `in_FRIENDREQUESTLIST` -> `get_friend_request_list` worker + `_friendrequestlist_send` callback

The worker thread does the pure DB read and returns plain data (id / (id, reason|msg) lists). The reactor-thread callback resolves usernames via `clientFromID` and sends the framed reply.

## Concurrency reasoning
- **Split rule honoured:** workers return plain lists only; no ORM rows cross threads, no shared-dict access on the worker.
- **Session bracket:** `clientFromID(id, True)` can do a reactor-side DB query *and* an offline-cache write on a cache miss, so each callback brackets the reactor session with `commit_guard/rollback_guard/close_guard`, exactly like `_login_finish` (these callbacks run outside `dataReceived`'s per-request guard).
- **Disconnect race:** each callback guards `client.session_id in clients` before sending (client may drop during the DB call).
- **No new locks / no new mutation:** the only shared-state write is the offline-user cache inside `clientFromID`, which already runs on the reactor thread. Nothing else is mutated.
- **No interleaving:** each list is framed BEGIN..END and built in a single synchronous callback that never yields, so concurrent list commands can't interleave their lines. Two *different* list replies could arrive in swapped order if they race, but each stays individually well-formed (protocol-safe).
- A shared `_social_list_failed` errback logs DB errors loudly; these commands have no protocol-level failure reply.

## Testing (real MariaDB, threaded path exercised)
sqlite can't exercise this path (forces max_threads=1). Tested against MariaDB:
- 20 concurrent viewers x 5 rounds x 3 list commands = 300 list reads; all replies well-framed (exactly one BEGIN/END each) and contents matched the seeded relationships.
- Disconnect-during-call: 10 'send list then immediately drop socket' iterations; no tracebacks (disconnect guard works).
- server.log clean of session/ORM/serialization errors (only the documented harmless boot-time file-load errors).

## Scope
One handler group, per the incremental Phase 3 plan. No schema or protocol changes.