### PR TITLE
Run the channel history reads off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -2268,10 +2268,29 @@ class Protocol:
 		except:
 			self.out_FAILED(client, "GETCHANNELMESSAGES", "Invalid id", True)
 			return
-		msgs = self.userdb.get_channel_messages(client.user_id, channel.id, last_msg_id)
+		# 3.1: read channel history off the reactor thread. The worker returns plain
+		# [(datetime, username, msg, ex_msg, id), ...] - usernames are resolved inside the
+		# query (joins to User/BridgedUser), so the callback does NO reactor-side DB and
+		# needs no session bracket; it just formats + sends. A pure read, so no new races.
+		d = self._root.defer_db(self.userdb.get_channel_messages, client.user_id, channel.id, last_msg_id)
+		d.addCallback(self._channelmessages_send, client, chan)
+		d.addErrback(self._channelmessages_failed, client)
+
+	def _channelmessages_send(self, msgs, client, chan):
+		# reactor-thread callback: pure send, no DB -> no commit/rollback/close bracket.
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB call
 		for msg in msgs:
 			timestamp = int(time.mktime(msg[0].timetuple()))
 			self.out_JSON(client,  'SAID', {"chanName": chan, "time": str(timestamp), "userName": msg[1], "msg": msg[2], "ex_msg":msg[3], "id": msg[4]})
+
+	def _channelmessages_failed(self, failure, client):
+		# reactor-thread errback: a DB error fetching history. Log it loudly; unlike the
+		# read-only social lists, GETCHANNELMESSAGES has a protocol failure reply, so use it.
+		logging.error("GETCHANNELMESSAGES DB error for <%s>: %s" % (getattr(client, 'username', '?'), failure.getTraceback()))
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB call
+		self.out_FAILED(client, "GETCHANNELMESSAGES", "Server error fetching channel messages", True)
 
 	def in_RING(self, client, username):
 		'''


### PR DESCRIPTION
## What

Converts `in_GETCHANNELMESSAGES` to run its `get_channel_messages` DB read off the
reactor thread via `defer_db`/`_run_db`, following the read->reply pattern established
for the LOGIN flow (#10) and the social list reads (#11).

- Reactor pre-checks (channel exists, registered id, joined, `last_msg_id` parseable)
  stay on the reactor thread, unchanged.
- The worker runs `get_channel_messages` and returns plain tuples
  `[(datetime, username, msg, ex_msg, id), ...]`. Usernames are resolved **inside the
  query** (outer joins to `User`/`BridgedUser`), so no live ORM rows cross the thread
  boundary and the callback needs no DB session.
- `_channelmessages_send` (reactor-thread callback) formats + sends the `SAID` lines.
  Because it does **no** reactor-side DB (no `clientFromID`), it needs **no**
  `commit/rollback/close` session bracket — unlike the social-list callbacks.
- `_channelmessages_failed` errback logs and replies `FAILED` (this command, unlike the
  read-only social lists, has a protocol failure path).
- Both callbacks guard `client.session_id in clients` for disconnect-during-DB.

## Races

None introduced. This is a pure read: concurrent `GETCHANNELMESSAGES` from different
clients don't contend, and reads never need the `_run_db` serialization retry. The
message-ordering concern (autoincrement history id vs live broadcast order) is purely a
*write*-side issue in `SAY` and is deliberately left for a later PR.

## Testing

Against real MariaDB (sqlite can't exercise the threaded path). Seeded a registered
channel + 6 history rows, then 20 concurrent viewers x 5 rounds each JOIN and call
`GETCHANNELMESSAGES`:

- PASS: every reply returns all 6 messages, in ascending id order, with correct
  usernames / msg / ex_msg, under concurrency.
- PASS: invalid `last_msg_id` -> `FAILED Invalid id`.
- Disconnect-during-call (fire then drop socket x10): no tracebacks from the new
  callbacks in `server.log`.

Note: `server.log` shows a pre-existing, unrelated `ChanServClient.Send() takes 2
positional arguments but 3 were given` traceback from `DataHandler.broadcast` on JOIN
(ChanServ is a member of every channel). It is not touched or caused by this change and
reproduces on master; flagged separately.