### PR TITLE
Run the friend mutations off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -926,6 +926,64 @@ class UsersHandler:
 		users = [(req.user_id, req.msg) for req in reqs]
 		return users
 
+	# 3.1 worker units for the friend mutations. Each runs on a thread-pool worker and does
+	# the whole check-then-act as ONE uncommitted transaction: DataHandler._run_db commits it
+	# once and can safely retry the entire unit on a transient serialization error. They must
+	# NOT call the self-committing helpers above (friend_users / add_friend_request / ...),
+	# because an intermediate commit would be re-applied on retry. They take/return plain data
+	# only (ids, tuples) - never a live ORM row or an in-memory client - so they are
+	# thread-safe; the reactor-thread callback does all client notification.
+	def _user_id_from_username(self, username):
+		# cache-free, case-sensitive username -> id resolution. The offline-user cache in
+		# clientFromUsername must not be touched off the reactor thread, so query directly.
+		# db collation is case-insensitive, so require an exact match (mirrors clientFromUsername).
+		row = self.sess().query(User.id, User.username).filter(User.username == username).first()
+		if not row or row[1] != username:
+			return None
+		return row[0]
+
+	def do_friend_request(self, from_id, target_username, msg):
+		target_id = self._user_id_from_username(target_username)
+		if target_id is None:
+			return ('nouser',)
+		if self.are_friends(from_id, target_id):
+			return ('already_friends',)
+		if self.is_ignored(target_id, from_id):
+			# target ignores the sender; the ignore-set is kept in sync with this table for
+			# online users too, so the db check is correct whether the target is on- or offline
+			return ('silent',)
+		if self.has_friend_request(from_id, target_id):
+			return ('silent',)
+		self.sess().add(FriendRequest(from_id, target_id, msg))
+		return ('ok', target_id)
+
+	def do_accept_friend_request(self, accepter_id, target_username):
+		target_id = self._user_id_from_username(target_username)
+		if target_id is None:
+			return ('no_request',)
+		if not self.has_friend_request(target_id, accepter_id):
+			return ('no_request',)
+		self.sess().add(Friend(accepter_id, target_id))
+		self.sess().query(FriendRequest).filter(FriendRequest.user_id == target_id).filter(FriendRequest.friend_user_id == accepter_id).delete()
+		return ('ok', target_id)
+
+	def do_decline_friend_request(self, decliner_id, target_username):
+		target_id = self._user_id_from_username(target_username)
+		if target_id is None:
+			return ('no_request',)
+		if not self.has_friend_request(target_id, decliner_id):
+			return ('no_request',)
+		self.sess().query(FriendRequest).filter(FriendRequest.user_id == target_id).filter(FriendRequest.friend_user_id == decliner_id).delete()
+		return ('ok',)
+
+	def do_unfriend(self, user_id, target_username):
+		target_id = self._user_id_from_username(target_username)
+		if target_id is None:
+			return ('nouser',)
+		self.sess().query(Friend).filter(Friend.first_user_id == user_id).filter(Friend.second_user_id == target_id).delete()
+		self.sess().query(Friend).filter(Friend.second_user_id == user_id).filter(Friend.first_user_id == target_id).delete()
+		return ('ok', target_id)
+
 	def add_channel_message(self, channel_id, user_id, bridged_id, msg, ex_msg, date=None):
 		if date is None:
 			date = datetime.now()

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -1628,27 +1628,38 @@ class Protocol:
 		if not username:
 			self.out_SERVERMSG(client, "Missing userName argument.")
 			return
-		msg = tags.get("msg")
-
-		friendRequestClient = self.clientFromUsername(username, True)
-		if not friendRequestClient:
-			self.out_SERVERMSG(client, "No such user.")
-			return
 		if username == client.username:
 			self.out_SERVERMSG(client, "Can't send friend request to self. Sorry :(")
 			return
-		if self.userdb.are_friends(client.user_id, friendRequestClient.user_id):
+		msg = tags.get("msg")
+		# 3.1: resolve the target + run all the checks (are_friends / ignored / existing
+		# request) + insert the request as ONE atomic DB unit off the reactor thread. The
+		# checks move into the worker because the target may be offline (a DB hit) and the
+		# online ignore-set is kept in sync with the ignores table, so the db check is
+		# correct either way. Notify an online target in the callback.
+		d = self._root.defer_db(self.userdb.do_friend_request, client.user_id, username, msg)
+		d.addCallback(self._friendrequest_done, client, username, msg)
+		d.addErrback(self._friend_op_failed, client, "FRIENDREQUEST")
+
+	def _friendrequest_done(self, verdict, client, username, msg):
+		# reactor-thread callback: no reactor-side DB (clientFromID is memory-only here),
+		# so no session bracket; it only sends protocol messages.
+		if client.session_id not in self._root.clients:
+			return # requester disconnected during the DB op (the request was still stored)
+		kind = verdict[0]
+		if kind == 'nouser':
+			self.out_SERVERMSG(client, "No such user.")
+			return
+		if kind == 'already_friends':
 			self.out_SERVERMSG(client, "Already friends with user.")
 			return
-		if self.is_ignored(friendRequestClient, client):
-			# don't send friend request if ignored
+		if kind == 'silent':
+			# ignored, or a request already exists - stay silent so the sender can't probe it
 			return
-		if self.userdb.has_friend_request(client.user_id, friendRequestClient.user_id):
-			# don't inform the user that there is already a friend request (so they won't be able to tell if they are being ignored or not)
-			return
-
-		self.userdb.add_friend_request(client.user_id, friendRequestClient.user_id, msg)
-		if self.clientFromID(friendRequestClient.user_id):
+		# kind == 'ok'
+		target_id = verdict[1]
+		friendRequestClient = self.clientFromID(target_id) # online only (memory)
+		if friendRequestClient:
 			if msg:
 				friendRequestClient.Send('FRIENDREQUEST userName=%s\tmsg=%s' % (client.username, msg))
 			else:
@@ -1662,17 +1673,23 @@ class Protocol:
 		if not username:
 			self.out_SERVERMSG(client, "Missing userName argument.")
 			return
+		# 3.1: verify the request exists + create the friendship + delete the request as ONE
+		# atomic DB unit off the reactor; notify an online requester in the callback.
+		d = self._root.defer_db(self.userdb.do_accept_friend_request, client.user_id, username)
+		d.addCallback(self._acceptfriend_done, client, username)
+		d.addErrback(self._friend_op_failed, client, "ACCEPTFRIENDREQUEST")
 
-		friendRequestClient = self.clientFromUsername(username, True)
-		if not self.userdb.has_friend_request(friendRequestClient.user_id, client.user_id):
+	def _acceptfriend_done(self, verdict, client, username):
+		if client.session_id not in self._root.clients:
+			return # requester disconnected during the DB op (the friendship was still created)
+		if verdict[0] == 'no_request':
 			self.out_SERVERMSG(client, "No such friend request.")
 			return
-
-		self.userdb.friend_users(client.user_id, friendRequestClient.user_id)
-		self.userdb.remove_friend_request(friendRequestClient.user_id, client.user_id)
-
+		# kind == 'ok'
+		target_id = verdict[1]
 		client.Send('FRIEND userName=%s' % username)
-		if self.clientFromID(friendRequestClient.user_id):
+		friendRequestClient = self.clientFromID(target_id) # online only (memory)
+		if friendRequestClient:
 			friendRequestClient.Send('FRIEND userName=%s' % client.username)
 
 	def in_DECLINEFRIENDREQUEST(self, client, tags):
@@ -1682,12 +1699,16 @@ class Protocol:
 		if not username:
 			self.out_SERVERMSG(client, "Missing userName argument.")
 			return
+		# 3.1: verify + delete the request as ONE atomic DB unit off the reactor.
+		d = self._root.defer_db(self.userdb.do_decline_friend_request, client.user_id, username)
+		d.addCallback(self._declinefriend_done, client)
+		d.addErrback(self._friend_op_failed, client, "DECLINEFRIENDREQUEST")
 
-		friendRequestClient = self.clientFromUsername(username, True)
-		if not self.userdb.has_friend_request(friendRequestClient.user_id, client.user_id):
-			self.out_SERVERMSG(client, "No such friend request.")
+	def _declinefriend_done(self, verdict, client):
+		if client.session_id not in self._root.clients:
 			return
-		self.userdb.remove_friend_request(friendRequestClient.user_id, client.user_id)
+		if verdict[0] == 'no_request':
+			self.out_SERVERMSG(client, "No such friend request.")
 
 	def in_UNFRIEND(self, client, tags):
 		tags = self._parseTags(tags)
@@ -1696,14 +1717,33 @@ class Protocol:
 		if not username:
 			self.out_SERVERMSG(client, "Missing userName argument.")
 			return
+		# 3.1: resolve + delete the friendship (both directions) as ONE atomic DB unit off
+		# the reactor; notify an online ex-friend in the callback.
+		d = self._root.defer_db(self.userdb.do_unfriend, client.user_id, username)
+		d.addCallback(self._unfriend_done, client, username)
+		d.addErrback(self._friend_op_failed, client, "UNFRIEND")
 
-		friendRequestClient = self.clientFromUsername(username, True)
-
-		self.userdb.unfriend_users(client.user_id, friendRequestClient.user_id)
-
+	def _unfriend_done(self, verdict, client, username):
+		if client.session_id not in self._root.clients:
+			return
+		if verdict[0] == 'nouser':
+			# the original crashed on a missing user here; reply gracefully instead
+			self.out_SERVERMSG(client, "No such user.")
+			return
+		# kind == 'ok'
+		target_id = verdict[1]
 		client.Send('UNFRIEND userName=%s' % username)
-		if self.clientFromID(friendRequestClient.user_id):
+		friendRequestClient = self.clientFromID(target_id) # online only (memory)
+		if friendRequestClient:
 			friendRequestClient.Send('UNFRIEND userName=%s' % client.username)
+
+	def _friend_op_failed(self, failure, client, op):
+		# reactor-thread errback shared by the friend mutations: a DB error means the
+		# mutation did not happen. Log it loudly and tell the requester.
+		logging.error("%s DB error for <%s>: %s" % (op, getattr(client, 'username', '?'), failure.getTraceback()))
+		if client.session_id not in self._root.clients:
+			return
+		self.out_SERVERMSG(client, "Server error processing %s." % op)
 
 	def in_FRIENDREQUESTLIST(self, client):
 		client.Send('FRIENDREQUESTLISTBEGIN')


### PR DESCRIPTION
## What

Converts the friend-mutation handlers (`FRIENDREQUEST`, `ACCEPTFRIENDREQUEST`,
`DECLINEFRIENDREQUEST`, `UNFRIEND`) to run their DB work off the reactor thread via
`defer_db`/`_run_db`. First *write* group, following the read->reply pattern from the
LOGIN flow (#10) and the social/channel reads (#11, #12).

Each handler now:
- Does memory-only pre-checks on the reactor (parse tags, missing-`userName`,
  self-request).
- Defers a single **atomic** worker unit (new `UsersHandler.do_*` methods) that resolves
  the target, runs the check, and applies the mutation as **one uncommitted transaction**.
- Notifies the requester + an online target in a reactor-thread callback.

## Why the worker is one uncommitted transaction

`_run_db` retries the whole worker fn on a transient serialization error
(deadlock/lock-wait), so an intermediate commit would be re-applied on retry. The
existing low-level helpers (`friend_users`, `add_friend_request`, `remove_friend_request`,
`unfriend_users`) each `commit()` internally, so the new `do_*` methods deliberately do
**not** call them - they issue the raw `add`/`delete` and let `_run_db` commit once. The
whole check-then-act is therefore a single transaction (atomicity for check-then-act).

## State-ownership rules honoured

- Workers take/return plain data only (ids, small tuples) - never a live ORM row or an
  in-memory client object.
- Target resolution uses a new cache-free `_user_id_from_username` (a direct query),
  because `clientFromUsername` reads/writes the shared 1.2 offline-user cache and must
  not be touched off the reactor thread.
- The ignore-check (`FRIENDREQUEST`) is done in the worker against the `ignores` table.
  For online users that table is kept in sync with the in-memory `client.ignored` set, so
  the DB answer is identical, and the worker never reads reactor-owned memory.
- These tables (`friends` / `friendRequests`) are not cached in memory and are unrelated
  to the `users` cache, so there is **no cache invalidation** to do - callbacks are pure
  send. No reactor-side DB in any callback, so no session bracket is needed.
- Every callback guards `client.session_id in clients` for disconnect-during-DB.

## Races

- **Concurrent independent mutations** (different user pairs): distinct rows, no
  contention; verified below.
- **Same-pair concurrent double-accept / double-request**: `friends` and `friendRequests`
  have **no unique constraint**, so two concurrent accepts of the *same* request (same
  user, two connections) could in principle create a duplicate `friends` row. This is a
  pre-existing exposure (the original was protected only by single-threadedness) and is
  degenerate in practice; left as-is rather than adding a schema change. Documented here.

## Behaviour-preservation notes

- `userdb.are_friends()` is pre-existing-**asymmetric** (it matches
  `first_user_id==X OR second_user_id==Y`, not the specific pair). This conversion reuses
  it unchanged and preserves the `Friend(accepter, requester)` row orientation, so the
  "Already friends with user." guard fires for exactly the same inputs as on master.
- `ACCEPT`/`DECLINE`/`UNFRIEND` previously dereferenced `clientFromUsername(...).user_id`
  with no nil-check and would crash on a non-existent target. The workers now return a
  graceful verdict instead (`No such friend request.` / `No such user.`).

## Testing

Against real MariaDB (sqlite can't exercise the threaded path):
- Functional (online target): request+notify, duplicate-request is silent + no extra row,
  accept notifies both sides + creates friendship + clears request, already-friends
  rejected, unfriend notifies both + removes row, decline clears request, and the
  error paths (self, no-such-user, no-such-request) - all correct.
- Concurrency: 20 independent requester/target pairs accept concurrently - every pair
  friended exactly once and every request cleared, 0 bad.
- Same-pair double-accept: 1 resulting friends row this run (race not manifested;
  documented above).
- Disconnect-during-call: 8x UNFRIEND-then-immediately-drop - no tracebacks from the new
  workers or callbacks in `server.log`.

Note: `server.log` still shows the pre-existing, unrelated `ChanServClient.Send() takes 2
positional arguments but 3 were given` traceback from `DataHandler.broadcast` at boot
(ChanServ auto-joining channels); not touched or caused by this change.