### PR TITLE
Run the SAY channel-history stores off the reactor thread, serialized per channel (OPTIMIZATIONS 3.1)

### DIFF
--- a/protocol/Channel.py
+++ b/protocol/Channel.py
@@ -1,4 +1,5 @@
 import time
+from collections import deque
 from datetime import datetime
 from datetime import timedelta
 
@@ -35,6 +36,13 @@ class Channel():
 		self.bridged_ban = {} #bridged_ids
 
 		self.forwards = set() #channel_names
+
+		# 3.1: per-channel FIFO queue for deferred channel_history stores. Drained one store
+		# at a time (history_inflight guards re-entry) so the INSERTs commit in arrival order,
+		# keeping the autoincrement id order == the live broadcast order. Touched only on the
+		# reactor thread (enqueue from in_SAY*, pump from the deferred callbacks), so no lock.
+		self.history_queue = deque()
+		self.history_inflight = False
 
 
 	def db(self):

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -1293,7 +1293,8 @@ class Protocol:
 			client.Send('CHANNELMESSAGE %s You are %s.' % (chan, channel.getMuteMessage(client)))
 			return
 		if channel.store_history:
-			self.userdb.add_channel_message(channel.id, client.user_id, None, msg, False)
+			# 3.1: persist off the reactor, serialized per channel to preserve id order
+			self._enqueue_channel_store(channel, client.user_id, None, msg, False)
 
 		self._root.broadcast('SAID %s %s %s' % (chan, client.username, msg), chan, set([]), client, 'u')
 		
@@ -1329,8 +1330,9 @@ class Protocol:
 		if channel.isMuted(client):
 			client.Send('CHANNELMESSAGE %s You are %s.' % (chan, channel.getMuteMessage(client)))
 			return
-		if channel.store_history: 
-			self.userdb.add_channel_message(channel.id, client.user_id, None, msg, True)
+		if channel.store_history:
+			# 3.1: persist off the reactor, serialized per channel to preserve id order
+			self._enqueue_channel_store(channel, client.user_id, None, msg, True)
 
 		self._root.broadcast('SAIDEX %s %s %s' % (chan, client.username, msg), chan, set([]), client, 'u')
 
@@ -1536,8 +1538,9 @@ class Protocol:
 		if not bridgedClient.bridged_id in channel.bridged_users:
 			self.out_FAILED(client, "SAYFROM", "Bridged user <%s> not present in channel" % bridgedClient.username, False)
 			return
-		if channel.store_history: 
-			self.userdb.add_channel_message(channel.id, client.user_id, bridgedClient.bridged_id, msg, False)
+		if channel.store_history:
+			# 3.1: persist off the reactor, serialized per channel to preserve id order
+			self._enqueue_channel_store(channel, client.user_id, bridgedClient.bridged_id, msg, False)
 
 		self._root.broadcast('SAIDFROM %s %s %s' % (chan, bridgedClient.username, msg), chan, set([]), client, 'u')
 		
@@ -1547,7 +1550,45 @@ class Protocol:
 			self._root.broadcast('SAIDBATTLE %s %s' % (client.username, msg), chan, set([]), client, None, 'u')
 		else:
 			self._root.broadcast('SAID %s %s %s' % (chan, client.username, msg), chan, set([]), client, None, 'u')
-		
+
+	# 3.1: per-channel serialized history store. The live SAID/SAIDEX/SAIDFROM broadcast
+	# already went out on the reactor in arrival order; here we persist the message off the
+	# reactor without reordering it. Each channel drains its queue one INSERT at a time, so
+	# the channel_history autoincrement ids stay monotonic with arrival order and
+	# GETCHANNELMESSAGES catch-up matches what live users saw.
+	_channel_store_max = 10000 # per-channel backlog cap; only reached if the DB stalls badly
+
+	def _enqueue_channel_store(self, channel, user_id, bridged_id, msg, ex_msg):
+		# reactor thread only. Append the store and kick the pump if idle.
+		if len(channel.history_queue) >= self._channel_store_max:
+			# DB is not keeping up; drop loudly rather than grow without bound (fail loud)
+			logging.error("channel %s history backlog full (%d); dropping a stored message" % (channel.id, self._channel_store_max))
+			return
+		channel.history_queue.append((user_id, bridged_id, msg, ex_msg))
+		self._pump_channel_store(channel)
+
+	def _pump_channel_store(self, channel):
+		# reactor thread only. Start the next store iff none is in flight for this channel.
+		if channel.history_inflight or not channel.history_queue:
+			return
+		channel.history_inflight = True
+		user_id, bridged_id, msg, ex_msg = channel.history_queue.popleft()
+		d = self._root.defer_db(self.userdb.add_channel_message, channel.id, user_id, bridged_id, msg, ex_msg)
+		d.addCallback(self._channel_store_done, channel)
+		d.addErrback(self._channel_store_failed, channel)
+
+	def _channel_store_done(self, result, channel):
+		# reactor-thread callback: store committed; release the slot and drain the next.
+		channel.history_inflight = False
+		self._pump_channel_store(channel)
+
+	def _channel_store_failed(self, failure, channel):
+		# reactor-thread errback: this store failed (the message was still broadcast live).
+		# Log it, then continue draining so one bad row does not stall the channel.
+		logging.error("channel %s history store failed: %s" % (channel.id, failure.getTraceback()))
+		channel.history_inflight = False
+		self._pump_channel_store(channel)
+
 	def in_IGNORE(self, client, tags):
 		'''
 		Tells the server to add the user to the client's ignore list. Doing this will prevent any SAID*, SAYPRIVATE and RING commands to be received from the ignored user.


### PR DESCRIPTION
## What

Moves the `channel_history` INSERT in `in_SAY` / `in_SAYEX` / `in_SAYFROM` off the reactor
thread via `defer_db`, while preserving message order. The live `SAID`/`SAIDEX`/`SAIDFROM`
broadcast still fires **synchronously** on the reactor (chat latency unchanged); only the
persistence is deferred.

## The race this addresses

`GETCHANNELMESSAGES` orders history by the `channel_history` autoincrement id. Today the
store runs synchronously before the broadcast, so history-id order == live broadcast order.
Naively deferring the store would let two concurrent messages' INSERTs commit out of arrival
order in the thread pool, so history catch-up would disagree with what live users saw (and
even a single sender's own messages can reorder, since they land on different worker threads).

## Approach: per-channel serialized stores

Each `Channel` gets a FIFO `history_queue` + an `history_inflight` flag (added in
`Channel.py`; `Battle` inherits via `Channel.__init__`). `in_SAY*` enqueue the store and the
channel drains it **one INSERT at a time** - the next store starts only from the previous
store's reactor-thread callback. So:

- INSERTs for a channel commit in arrival order -> autoincrement ids stay monotonic with the
  live broadcast order -> `GETCHANNELMESSAGES` matches what live users saw.
- `history_queue` / `history_inflight` are touched only on the reactor thread (enqueue from
  the handler, pump from Deferred callbacks, which Twisted fires on the reactor), so there is
  **no lock** despite coordinating thread-pool work.
- A failed store is logged and the channel keeps draining (one bad row doesn't stall it).
- The queue is bounded (`_channel_store_max = 10000`); if the DB stalls so badly that a single
  channel backs up that far, further stores are dropped with a loud error rather than growing
  without bound (fail loud, no silent truncation).

## New failure mode (named explicitly)

Today a failed INSERT aborts the whole handler (via `dataReceived`'s rollback), so the message
isn't broadcast either. With the deferred store, the message is **broadcast live first**, so a
later store failure means a message that users saw is absent from history (logged). This is an
inherent consequence of not blocking chat on the DB and is the intended trade-off.

## Testing

Against real MariaDB (sqlite can't exercise the threaded path). A pure listener in the channel
captures the ground-truth live broadcast order; `GETCHANNELMESSAGES` gives the stored
id-order; 8 concurrent senders blast 15 messages each (120 total):

- PASS: stored id-order == live broadcast order, exactly 120 rows, none lost, and each
  sender's own messages stay monotonic.
- **Discrimination check**: temporarily removing the in-flight gate (stores fire concurrently)
  makes the same test FAIL with an order mismatch at index 1 and scrambled per-sender order
  (`2,1,4,0,3,...`) - confirming the test actually catches reordering and that the serialization
  is what fixes it. Reverted; the committed code is the serialized version and re-verified PASS.
- No store-path tracebacks in `server.log`.

Note: `server.log` still shows the pre-existing, unrelated `ChanServClient.Send() takes 2
positional arguments but 3 were given` traceback from `DataHandler.broadcast` at boot
(ChanServ auto-joining channels); not touched or caused by this change.