### PR TITLE
Run IGNORE/UNIGNORE off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -984,6 +984,27 @@ class UsersHandler:
 		self.sess().query(Friend).filter(Friend.second_user_id == user_id).filter(Friend.first_user_id == target_id).delete()
 		return ('ok', target_id)
 
+	def _user_access_from_username(self, username):
+		# cache-free resolve returning (id, access) - the IGNORE mod/admin check needs the
+		# access string, which _user_id_from_username does not return. Mirrors that helper:
+		# case-sensitive exact match (db collation is case-insensitive, so re-check in python).
+		row = self.sess().query(User.id, User.username, User.access).filter(User.username == username).first()
+		if not row or row[1] != username:
+			return None
+		return (row[0], row[2])
+
+	def do_ignore_insert(self, user_id, ignore_user_id, reason):
+		# bare INSERT as ONE uncommitted unit (the reactor already validated). There is NO
+		# unique constraint on (user_id, ignored_user_id), so a concurrent same-target IGNORE
+		# from a second connection can still create a duplicate row; do_unignore_delete below
+		# tolerates and clears duplicates. A future migration should add the unique constraint.
+		self.sess().add(Ignore(user_id, ignore_user_id, reason))
+
+	def do_unignore_delete(self, user_id, unignore_user_id):
+		# tolerant DELETE (no .one(), unlike unignore_user) so a duplicate row from the
+		# no-unique-constraint race cannot raise MultipleResultsFound and can never be orphaned.
+		self.sess().query(Ignore).filter(Ignore.user_id == user_id).filter(Ignore.ignored_user_id == unignore_user_id).delete()
+
 	def add_channel_message(self, channel_id, user_id, bridged_id, msg, ex_msg, date=None):
 		if date is None:
 			date = datetime.now()

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -799,14 +799,6 @@ class Protocol:
 		else:
 			return self.userdb.is_ignored(client.user_id, ignoredClient.user_id)
 
-	def ignore_user(self, client, ignoreClient, reason=None):
-		self.userdb.ignore_user(client.user_id, ignoreClient.user_id, reason)
-		client.ignored[ignoreClient.user_id] = True
-
-	def unignore_user(self, client, unignoreClient):
-		self.userdb.unignore_user(client.user_id, unignoreClient.user_id)
-		client.ignored.pop(unignoreClient.user_id)
-
 	# Begin incoming protocol section #
 	#
 	# any function definition beginning with in_ and ending with capital letters
@@ -1562,25 +1554,45 @@ class Protocol:
 			self.out_SERVERMSG(client, "Missing userName argument.")
 			return
 		reason = tags.get("reason")
+		# 3.1: resolve the target (id + access) off the reactor. The mod check needs the
+		# target's access; the already-ignored/list-full checks and the client.ignored
+		# mutation stay on the reactor thread (live memory) - see the callbacks below.
+		d = self._root.defer_db(self.userdb._user_access_from_username, username)
+		d.addCallback(self._ignore_resolved, client, username, reason)
+		d.addErrback(self._ignore_op_failed, client, "IGNORE")
 
-		ignoreClient = self.clientFromUsername(username, True)
-		if not ignoreClient:
+	def _ignore_resolved(self, resolved, client, username, reason):
+		# reactor-thread callback: resolved is (target_id, access) or None. No reactor-side DB
+		# here (only memory reads + a second deferred), so no session bracket is needed.
+		# Mid-checks run in the original order: nouser, mod, self, already-ignored, list-full.
+		if client.session_id not in self._root.clients:
+			return # issuer disconnected during the resolve
+		if resolved is None:
 			self.out_SERVERMSG(client, "No such user.")
 			return
-		if ignoreClient.access in ('mod', 'admin'):
+		target_id, access = resolved
+		if access in ('mod', 'admin'):
 			self.out_SERVERMSG(client, "Can't ignore a moderator.")
 			return
 		if username == client.username:
 			self.out_SERVERMSG(client, "Can't ignore self.")
 			return
-		if self.is_ignored(client, ignoreClient):
+		if target_id in client.ignored:
 			self.out_SERVERMSG(client, "User is already ignored.")
 			return
 		if len(client.ignored) >= 50:
 			self.out_SERVERMSG(client, "Ignore list full (50 users).")
 			return
+		# checks passed: do the bare INSERT off the reactor, then sync memory + reply.
+		d = self._root.defer_db(self.userdb.do_ignore_insert, client.user_id, target_id, reason)
+		d.addCallback(self._ignore_stored, client, username, target_id, reason)
+		d.addErrback(self._ignore_op_failed, client, "IGNORE")
 
-		self.ignore_user(client, ignoreClient, reason)
+	def _ignore_stored(self, result, client, username, target_id, reason):
+		# reactor-thread callback: the row is committed; sync in-memory state + reply.
+		if client.session_id not in self._root.clients:
+			return # issuer disconnected during the INSERT (the row was still stored)
+		client.ignored[target_id] = True # idempotent: safe even if a concurrent op set it
 		if not reason or not reason.strip():
 			client.Send('IGNORE userName=%s' % (username))
 		else:
@@ -1598,16 +1610,41 @@ class Protocol:
 		if not username:
 			self.out_SERVERMSG(client, "Missing userName argument.")
 			return
-		unignoreClient = self.clientFromUsername(username, True)
-		if not unignoreClient:
+		# 3.1: resolve off the reactor (reuse the IGNORE resolver; access is unused here).
+		# The not-ignored check reads live memory and the DELETE runs off the reactor.
+		d = self._root.defer_db(self.userdb._user_access_from_username, username)
+		d.addCallback(self._unignore_resolved, client, username)
+		d.addErrback(self._ignore_op_failed, client, "UNIGNORE")
+
+	def _unignore_resolved(self, resolved, client, username):
+		# reactor-thread callback: only memory + a second deferred, so no session bracket.
+		if client.session_id not in self._root.clients:
+			return # issuer disconnected during the resolve
+		if resolved is None:
 			self.out_SERVERMSG(client, "No such user.")
 			return
-		if not self.is_ignored(client, unignoreClient):
+		target_id = resolved[0]
+		if target_id not in client.ignored:
 			self.out_SERVERMSG(client, "User is not ignored.")
 			return
+		d = self._root.defer_db(self.userdb.do_unignore_delete, client.user_id, target_id)
+		d.addCallback(self._unignore_removed, client, username, target_id)
+		d.addErrback(self._ignore_op_failed, client, "UNIGNORE")
 
-		self.unignore_user(client, unignoreClient)
+	def _unignore_removed(self, result, client, username, target_id):
+		# reactor-thread callback: the row(s) are deleted; sync in-memory state + reply.
+		if client.session_id not in self._root.clients:
+			return # issuer disconnected during the DELETE (the row was still removed)
+		client.ignored.pop(target_id, None) # tolerant: may already be gone via a race
 		client.Send('UNIGNORE userName=%s' % (username))
+
+	def _ignore_op_failed(self, failure, client, op):
+		# reactor-thread errback shared by IGNORE/UNIGNORE: a DB error means the mutation did
+		# not happen, so client.ignored is left untouched (DB and memory stay consistent).
+		logging.error("%s DB error for <%s>: %s" % (op, getattr(client, 'username', '?'), failure.getTraceback()))
+		if client.session_id not in self._root.clients:
+			return
+		self.out_SERVERMSG(client, "Server error processing %s." % op)
 
 	def in_IGNORELIST(self, client):
 		# 3.1: read the ignore list off the reactor thread, then format + send in


### PR DESCRIPTION
Converts `in_IGNORE`/`in_UNIGNORE` to run their blocking SQLAlchemy work in the thread pool via `defer_db`, continuing the Phase 3 (3.1) async-DB slice. Follows the friend-mutation pattern (#13), with one extra concern: the issuer's in-memory ignore set `client.ignored`.

## Approach: two-hop, memory stays on the reactor

The issuer is always online, so the already-ignored and list-full checks are pure in-memory reads that must not cross into a worker thread. Rather than snapshot `client.ignored` into a single worker, this uses two hops so every memory check runs on live state on the reactor:

```
hop 1 (worker)   _user_access_from_username -> (id, access) or None
reactor callback nouser / mod / self / already-ignored / list-full
                 (original error-message order, live client.ignored)
hop 2 (worker)   bare INSERT / DELETE, one uncommitted unit (_run_db commits/retries)
reactor callback update client.ignored + send reply
```

IGNORE/UNIGNORE are rare commands, so the extra round-trip's latency is irrelevant; the payoff is that no in-memory state or policy evaluation leaves the reactor thread.

### New worker units (SQLUsers.py)
- `_user_access_from_username` — cache-free sibling of `_user_id_from_username` that also returns `access` (needed for the mod/admin check; correct for on- and offline targets).
- `do_ignore_insert` — bare `Ignore` INSERT, one uncommitted unit.
- `do_unignore_delete` — tolerant `filter(...).delete()`.

## The `.one()` / duplicate-row hazard

The `ignores` table has **no unique constraint** on `(user_id, ignored_user_id)`. Because the already-ignored check reads memory that's only updated after the INSERT round-trips, two concurrent same-target IGNOREs (even from one client across two connections) can both pass the check and both INSERT a duplicate row. `userdb.unignore_user` uses `.one()`, which would then raise `MultipleResultsFound` and break a later UNIGNORE.

`do_unignore_delete` uses a tolerant `filter(...).delete()` (no `.one()`), so duplicates are cleared and can never be orphaned. **A future migration should add the unique constraint** to prevent the duplicate at the source (fits the Register slice's IntegrityError work).

## Concurrency notes
- **Worker errback leaves memory untouched** — `_ignore_stored`/`_unignore_removed` run only on success; the shared `_ignore_op_failed` errback never touches `client.ignored`, so DB and memory stay consistent on failure.
- **Disconnect mid-DB** — every callback guards `client.session_id in self._root.clients`. If the issuer drops after a write, the row persists and memory is rebuilt from DB at next login.
- **DB-vs-memory visibility** — there is a sub-ms window between the INSERT commit and the memory set where a consumer reading the issuer's memory (e.g. broadcast filter) could let one message through. The synchronous original had no such window; this is a minor, honestly-noted relaxation for a rare command.

## Cleanup
- Removes the now-orphaned Protocol wrappers `ignore_user`/`unignore_user` (only callers were the two handlers rewritten here).
- Leaves the self-committing `userdb.ignore_user`/`unignore_user` in place (now unused), matching #13 which kept its old self-committing friend helpers.

## Testing

Real MariaDB (sqlite can't exercise the threaded path). Functional matrix (missing arg, no-such-user, mod target offline, self, ignore+reason, already-ignored, unignore, not-ignored, unignore-no-such-user), 20 independent concurrent ignore pairs, same-pair double-ignore race, and disconnect-during-call. All functional checks pass, no new server tracebacks.

The in-memory path is verified specifically: after IGNORE, the target's PM to the issuer is dropped (reads `client.ignored`); after UNIGNORE it gets through. A discrimination run with the memory update removed produced 5 failures (PM leak + already-ignored + cascading UNIGNORE), confirming the test catches the regression; restored code is green. Tolerant-delete heal verified: a duplicated pair is fully cleared by one UNIGNORE.