### PR TITLE
Run the MYSTATUS ingame-time and logout writes off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -651,14 +651,17 @@ class UsersHandler:
 			self.invalidate_user_cache(user_id, uname)
 
 
-	def end_session(self, user_id):
+	def do_end_session(self, user_id):
+		# 3.1 worker: PURE DB, one uncommitted transaction (defer_db/_run_db owns the
+		# commit and retries on serialization errors). Returns the plain username for the
+		# reactor callback to invalidate the 1.2 cache with; never touches the cache itself.
+		# Idempotent: if the most recent login is already ended, do nothing and return None.
 		entry = self.sess().query(User).filter(User.id==user_id).first()
-		if entry and not entry.logins[-1].end:
-			entry.logins[-1].end = datetime.now()
-			entry.last_login = datetime.now() # in real its last online / last seen
-			uname = entry.username
-			self.sess().commit()
-			self.invalidate_user_cache(user_id, uname)
+		if not entry or not entry.logins or entry.logins[-1].end:
+			return None
+		entry.logins[-1].end = datetime.now()
+		entry.last_login = datetime.now() # in real its last online / last seen
+		return entry.username
 
 	def check_user_name(self, user_name):
 		if len(user_name) > 20: return False, 'Username too long'
@@ -731,6 +734,20 @@ class UsersHandler:
 		uid = entry.id if entry is not None else None
 		self.sess().commit()
 		self.invalidate_user_cache(uid, obj.username)
+
+	def do_set_ingame_time(self, username, ingame_time):
+		# 3.1 worker: PURE DB, one uncommitted transaction. MYSTATUS only ever changes
+		# ingame_time; we write the ABSOLUTE total (the reactor already incremented the
+		# in-memory client.ingame_time) so a _run_db retry re-applies the same value rather
+		# than double-counting. Other User fields are left untouched on purpose - this avoids
+		# clobbering a field a concurrent handler (e.g. CHANGEPASSWORD) may have just written,
+		# the race that deferring the old all-field save_user would have opened. Returns the
+		# user id for the reactor callback to invalidate the 1.2 cache with.
+		entry = self.sess().query(User).filter(User.username==username).first()
+		if entry is None:
+			return None
+		entry.ingame_time = ingame_time
+		return entry.id
 
 	def get_user_id_with_email(self, email):
 		if email == '':

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -319,10 +319,28 @@ class Protocol:
 			del self._root.user_ids[client.user_id]
 		#note: self._root.clients is managed by twistedserver.py
 
-		self.userdb.end_session(client.user_id)
+		# 3.1: persist the logout (login end + last_login) off the reactor thread. The
+		# in-memory teardown above already removed the client from usernames/user_ids, and
+		# RemoveUser is broadcast immediately below - neither waits on the DB write.
+		d = self._root.defer_db(self.userdb.do_end_session, client.user_id)
+		d.addCallback(self._end_session_done, client.user_id)
+		d.addErrback(self._end_session_failed, client.user_id)
 
 		# inform that the client left
 		self.broadcast_RemoveUser(client)
+
+	def _end_session_done(self, username, user_id):
+		# reactor-thread callback: the client is already being torn down, so we hold no
+		# client ref - only the plain user_id we passed in and the username the worker
+		# returned. Pure memory (1.2 cache invalidation), so no membership guard and no
+		# session bracket. username is None when the login was already ended (no-op).
+		if username is None:
+			return
+		self.userdb.invalidate_user_cache(user_id, username)
+
+	def _end_session_failed(self, failure, user_id):
+		# the logout timestamp did not get recorded; the in-memory teardown still happened.
+		logging.error("end_session persist failed for user_id %s: %s" % (user_id, failure.getTraceback()))
 
 
 	def get_function_args(self, client, command, function, numspaces, args):
@@ -2317,8 +2335,25 @@ class Protocol:
 			ingame_time = (time.time() - client.went_ingame) / 60
 			if ingame_time >= 1:
 				client.ingame_time += int(ingame_time)
-				self.userdb.save_user(client)
+				# 3.1: persist the new ingame_time off the reactor thread. The in-memory
+				# total is already updated above and the CLIENTSTATUS broadcast below does
+				# not wait on the DB write.
+				d = self._root.defer_db(self.userdb.do_set_ingame_time, client.username, client.ingame_time)
+				d.addCallback(self._ingame_time_saved, client.user_id, client.username)
+				d.addErrback(self._ingame_time_save_failed, client.username)
 		self._root.broadcast('CLIENTSTATUS %s %d'%(client.username, client.status))
+
+	def _ingame_time_saved(self, uid, user_id, username):
+		# reactor-thread callback: pure memory (1.2 cache invalidation), no session bracket.
+		# uid is None only if the user vanished from the db mid-flight (not expected here).
+		if uid is None:
+			return
+		self.userdb.invalidate_user_cache(user_id, username)
+
+	def _ingame_time_save_failed(self, failure, username):
+		# the ingame_time stat did not persist; the in-memory client.ingame_time is ahead of
+		# the db and a later save will reconcile it.
+		logging.error("MYSTATUS ingame_time persist failed for <%s>: %s" % (username, failure.getTraceback()))
 
 	def in_CHANNELS(self, client):
 		'''


### PR DESCRIPTION
Part of Phase 3 (OPTIMIZATIONS.md 3.1): move blocking SQLAlchemy writes off the single Twisted reactor thread via the established `defer_db` worker pattern. This slice converts two write paths:

- **logout** (`Protocol` disconnect cleanup, formerly `userdb.end_session`)
- **MYSTATUS** ingame-time persist (formerly `userdb.save_user(client)` on the ingame->not-ingame transition)

Independent of the open SAY (#14) and IGNORE/UNIGNORE (#15) PRs; branched off `master`.

## Pattern
Same split as the merged friend/social PRs: the worker does **pure DB I/O, one uncommitted transaction**, returns plain data; `_run_db` owns the commit and retries transient serialization errors; the reactor-thread callback does the 1.2 user-cache invalidation. No shared state is touched off the reactor.

### New worker units (`SQLUsers.py`)
- `do_end_session(user_id)` -> returns the username (or `None` if the latest login was already ended). Replaces `end_session`, which had a single caller and is removed.
- `do_set_ingame_time(username, ingame_time)` -> returns the user id (or `None`). Writes the **absolute** ingame_time total (the reactor already incremented the in-memory value) so a `_run_db` retry re-applies the same value rather than double-counting.

### Reactor callbacks (`protocol/Protocol.py`)
Both callbacks are pure memory (cache invalidation only), so no session bracket and no `session_id in clients` guard - they reference only plain values captured at call time, never a live client row.

## Design notes / races
- **MYSTATUS writes only `ingame_time`**, not the old all-field `save_user` snapshot. This is deliberate: `ingame_time` is the only field MYSTATUS owns, and a full-field write off-reactor could clobber a field a concurrent handler (e.g. CHANGEPASSWORD) had just written. Absolute-value write is also retry-safe. Net effect in the common case is identical to before; strictly safer under concurrency.
- **logout teardown ordering**: the in-memory cleanup (remove from `usernames`/`user_ids`, `broadcast_RemoveUser`) stays synchronous on the reactor and no longer waits on the DB write. The worker captures only the plain `user_id`, so there is no torn-down-client race.
- Concurrent logouts touch distinct user rows -> no contention; concurrent MYSTATUS for the same user is last-write-wins, which is fine for a stat counter.
- On a worker error the errback logs loudly and mutates no shared state (the write did not happen).

## Testing (MariaDB; sqlite cannot exercise the threaded path)
- Worker-unit test of both DB units, including idempotency/retry-safety of `do_set_ingame_time` and the already-ended no-op of `do_end_session`. Discrimination check: a non-idempotent `+=` was caught by the retry-safety assertion.
- e2e logout test against a running server: functional logout populates `logins.end` + refreshes `last_login` via the deferred path; 20 concurrent login+disconnect all get their latest login ended in ~0.1s with no contention. Discrimination check: skipping the `end` write made both the functional and concurrent assertions fail.
- Honest limitation: the **full** MYSTATUS ingame-time path is not exercised end-to-end (it requires a >=60s in-battle session). It is covered by the worker-unit test plus code review of the handler wiring; the deferred-write machinery itself is exercised end-to-end by the logout test.