### PR TITLE
Run the REGISTER check and insert off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -698,6 +698,22 @@ class UsersHandler:
 		self.invalidate_user_cache(username=username)
 		return True, 'Account registered successfully.'
 
+	def do_register_insert(self, username, password, ip, email):
+		# 3.1 worker: INSERT the new account as one uncommitted transaction (defer_db/_run_db
+		# owns the commit). check_register_user already ran on the reactor, but a concurrent
+		# REGISTER or RENAMEACCOUNT can still win the same username/email in the gap before
+		# this insert, so catch the unique-constraint violation and report it as ('taken',)
+		# rather than letting a 1062 surface as a server error. On success returns the new id
+		# for the reactor callback; never touches the 1.2 cache (that stays on the reactor).
+		entry = User(username, password, ip, email)
+		self.sess().add(entry)
+		try:
+			self.sess().flush()  # forces the INSERT now so we can catch the dup here
+		except IntegrityError:
+			self.sess().rollback()
+			return ('taken',)
+		return ('ok', entry.id)
+
 	def rename_user(self, username, newname):
 		if newname == username:
 			return False, 'You already have that username.'

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -870,7 +870,7 @@ class Protocol:
 		@required.str password: Password to use (old-style: BASE64(MD5(PWRD)), new-style: BASE64(PWRD))
 		'''
 
-		# well formed-ness tests
+		# well formed-ness tests (memory only)
 		good, reason = self._validUsernameSyntax(username)
 		if not good:
 			client.Send("REGISTRATIONDENIED %s" % (reason))
@@ -881,10 +881,22 @@ class Protocol:
 			client.Send("REGISTRATIONDENIED %s" % (reason))
 			return
 
-		# test if user would be OK on db side (e.g. duplication)
+		# 3.1: two-hop async register, mirroring the LOGIN flow. Hop 1 runs the uniqueness +
+		# ban check (check_register_user) off the reactor thread; the memory-only checks and
+		# the INSERT continue in _register_checked, preserving the original denial ordering.
 		email = email.lower()
-		good, reason = self.userdb.check_register_user(username, email, client.ip_address)
-		if (not good):
+		d = self._root.defer_db(self.userdb.check_register_user, username, email, client.ip_address)
+		d.addCallback(self._register_checked, client, username, password, email)
+		d.addErrback(self._register_failed, client, username)
+
+	def _register_checked(self, verdict, client, username, password, email):
+		# reactor-thread callback after the uniqueness/ban check. Applies the same memory-only
+		# checks in the original order, then defers the INSERT (hop 2). No reactor-side DB here,
+		# so no session bracket.
+		if client.session_id not in self._root.clients:
+			return # registrant disconnected during the DB check
+		good, reason = verdict
+		if not good:
 			logging.info('[%s] Registration failed for user <%s>: %s' % (client.session_id, username, reason))
 			client.Send('REGISTRATIONDENIED %s' % reason)
 			return
@@ -899,39 +911,73 @@ class Protocol:
 		else:
 			email = None # avoid triggering uniqueness constraint with empty strings
 
-		# rate limit per ip
+		# rate limit per ip - stays AFTER the uniqueness check (so a failed-uniqueness attempt
+		# does not count) and on the reactor (it mutates _root.recent_registrations)
 		recent_regs = self._root.recent_registrations.get(client.ip_address, 0)
 		if recent_regs >= 3 and client.ip_address != self._root.online_ip:
 			client.Send("REGISTRATIONDENIED too many recent registration attempts, please try again later")
 			return
 		self._root.recent_registrations[client.ip_address] = recent_regs + 1
 
-		#save user to db
-		self.userdb.register_user(username, password, client.ip_address, email)
-		client_fromdb = self.clientFromUsername(username, True)
+		# hop 2: INSERT off the reactor; the worker catches the unique-constraint race.
+		d = self._root.defer_db(self.userdb.do_register_insert, username, password, client.ip_address, email)
+		d.addCallback(self._register_inserted, client, username, email)
+		d.addErrback(self._register_failed, client, username)
 
-		# verification
-		verif_reason = "registered an account on the " + self._root.mail_identity + " lobbyserver (username: %s)" % username
-		good, reason = self.verificationdb.check_and_send(client_fromdb.user_id, email, 4, verif_reason)
-		if (not good):
+	def _register_inserted(self, verdict, client, username, email):
+		# reactor-thread callback after the INSERT.
+		if client.session_id not in self._root.clients:
+			return # disconnected mid-insert; if the row was created that is fine (account exists)
+		if verdict[0] == 'taken':
+			# a concurrent REGISTER/RENAMEACCOUNT won the same name/email in the gap after the
+			# check; report it like the original duplicate path rather than a server error
+			client.Send('REGISTRATIONDENIED Username is already in use.')
+			return
+		user_id = verdict[1]
+		# invalidate the 1.2 cache on the reactor (covers the recreated-name edge), like
+		# register_user did. The worker must not touch the cache.
+		self.userdb.invalidate_user_cache(username=username)
+
+		# verification (DB; a no-op returning (True,'') when verification is inactive, which is
+		# the default). NOTE: when verification IS active this is still a synchronous reactor-side
+		# DB call - deferring the whole verification/email path is the later Account/verify slice.
+		# It runs outside dataReceived's session guard, so bracket the reactor session.
+		try:
+			verif_reason = "registered an account on the " + self._root.mail_identity + " lobbyserver (username: %s)" % username
+			good, reason = self.verificationdb.check_and_send(user_id, email, 4, verif_reason)
+			self._root.session_manager.commit_guard()
+		except:
+			logging.error(traceback.format_exc())
+			self._root.session_manager.rollback_guard()
+			good, reason = False, "internal error"
+		finally:
+			self._root.session_manager.close_guard()
+		if not good:
 			client.Send("REGISTRATIONDENIED %s" % ("verification failed: " + reason))
 			return
 
 		# declare success
 		client.access = 'agreement'
 		client.Send('REGISTRATIONACCEPTED')
-		
-		try: 
-			thread.start_new_thread(self._check_nonresidential_ip, (client_fromdb.user_id, client_fromdb.username, client.ip_address))
-		except: 
-			logging.error('Failed to launch _check_nonresidential_ip: %s, %s, %s' % (client_fromdb.user_id, client_fromdb.username, client.ip_address))
+
+		try:
+			thread.start_new_thread(self._check_nonresidential_ip, (user_id, username, client.ip_address))
+		except:
+			logging.error('Failed to launch _check_nonresidential_ip: %s, %s, %s' % (user_id, username, client.ip_address))
 
 		logging.info('[%s] Successfully registered user <%s>.' % (client.session_id, username))
 		ip_str = client.ip_address
 		if client.local_ip != client.ip_address:
 			ip_str += " " + client.local_ip
 		self.broadcast_Moderator('New: %s %s %s' %(username, ip_str, client.country_code))
-	
+
+	def _register_failed(self, failure, client, username):
+		# reactor-thread errback for either hop: the registration did not complete.
+		logging.error("REGISTER DB error for <%s>: %s" % (username, failure.getTraceback()))
+		if client.session_id not in self._root.clients:
+			return
+		client.Send("REGISTRATIONDENIED Server error processing registration.")
+
 	def _check_nonresidential_ip(self, user_id, username, ip_address):
 		if not self._root.iphub_xkey:
 			return


### PR DESCRIPTION
Part of Phase 3 (OPTIMIZATIONS.md 3.1): move the blocking REGISTER DB work off the single Twisted reactor thread. Independent of #14/#15/#16; branched off `master`.

Introduces the **DB-level uniqueness via IntegrityError** technique: the reactor-side uniqueness re-check can still race a concurrent same-name register, so the INSERT worker catches the unique-constraint violation and reports it as "name taken" rather than letting a 1062 surface as a server error. The `users.username` and `users.email` columns are both `unique=True`, which is what makes this correct.

## Flow (two-hop, mirroring the async LOGIN)
`in_REGISTER` now does the memory-only syntax checks, then:
- **Hop 1** `defer_db(check_register_user)` - uniqueness + ban check off-reactor. The callback `_register_checked` re-applies the memory-only checks **in the original order**: email-validity (only when verification is active), then the per-IP rate limit. The rate limit deliberately stays *after* the uniqueness check (so a failed-uniqueness attempt does not consume the limit) and on the reactor (it mutates `_root.recent_registrations`).
- **Hop 2** `defer_db(do_register_insert)` - the INSERT off-reactor, catching `IntegrityError` -> `('taken',)`. The callback `_register_inserted` invalidates the 1.2 cache on the reactor, then sends `REGISTRATIONACCEPTED` (or `REGISTRATIONDENIED` on the race).
- `_register_failed` errback handles a genuine DB error on either hop.

### New worker (`SQLUsers.py`)
`do_register_insert(username, password, ip, email)` - one uncommitted transaction (`_run_db` owns the commit), returns `('ok', new_id)` or `('taken',)`. Forces a `flush()` so the duplicate is caught here; on `IntegrityError` it rolls back and returns `('taken',)`. Never touches the 1.2 cache. `register_user` is left untouched (still used by the bot-account path).

## Scope decisions (surfaced deliberately)
- **`in_CREATEBOTACCOUNT` is NOT converted.** It is a low-frequency moderator command that also does `clientFromUsername` (cache-writing), creates a `Channel`, talks to chanserv, and calls `save_user` - a different, heavier group better handled with the admin/account slice. Converting it here would balloon this PR. (It also has a pre-existing `bot_client`-before-assignment bug in the `founder_username` branch, untouched.)
- **Verification stays synchronous on the reactor for this slice.** When verification is inactive (the default) `check_and_send` is a no-op returning `(True,'')`, so there is no blocking DB call at all. When it IS active it remains a synchronous reactor-side DB call (bracketed with the session guards, since the callback runs outside `dataReceived`); deferring the whole verification/email path belongs to the later Account/verify slice.

## Races enumerated
- **Concurrent same-name REGISTER**: reactor pre-check may pass for several at once (no row yet); the DB unique index admits exactly one INSERT, the rest hit `IntegrityError` -> `('taken',)` -> `REGISTRATIONDENIED`. Invariant: exactly one row, exactly one acceptance.
- **REGISTER racing RENAMEACCOUNT to the same name**: same `IntegrityError` path.
- **Disconnect mid-insert**: `_register_inserted` guards `session_id in clients`; if the row was already created that is fine (the account exists and can log in).

## Testing (MariaDB; sqlite cannot exercise the threaded path)
- Worker-unit test of `do_register_insert`: fresh insert -> `('ok', id)`; duplicate username -> `('taken',)` with no second row and a still-usable session; insert-after-caught-error works; duplicate email -> `('taken',)`. Discrimination check: removing the `IntegrityError` catch made the duplicate insert raise `(1062, "Duplicate entry ... for key 'username'")`, which the test caught.
- e2e against a running server: functional accept + one row; empty-password denial creates no row; sequential duplicate -> "already in use", no second row; **8 concurrent same-name registers -> exactly 1 accepted, 7 denied, 1 db row**. Full register -> login -> CONFIRMAGREEMENT flow re-verified with a fresh user (agreement gate -> access `user`).
- Honest notes: in the concurrent e2e run the duplicates happened to be caught at the hop-1 reactor pre-check rather than the hop-2 IntegrityError backstop (the inserts committed fast enough to close the window); the invariant held either way, and the IntegrityError backstop is covered deterministically by the worker-unit test + its discrimination check. The per-IP rate-limit branch is unchanged but not exercised e2e, because on localhost the client IP equals the server's online_ip and the limit is bypassed.