### PR TITLE
Run the CHANGEPASSWORD check and write off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -636,12 +636,19 @@ class UsersHandler:
 		self.sess().commit()
 		return snapshot
 
-	def set_user_password(self, username, password):
+	def do_change_password(self, username, cur_password, new_password):
+		# 3.1 worker: re-verify the current password and write the new one as ONE
+		# uncommitted transaction (atomic check-then-set; _run_db owns the commit).
+		# Returns ('denied', reason) without writing on a credential mismatch (or a
+		# vanished user), else ('ok', uid). Cache-free - the reactor callback does the
+		# 1.2 user-cache invalidation; this must not touch shared in-memory state.
+		good, reason = self.check_login_user(username, cur_password)
+		if not good:
+			return ('denied', reason)
 		dbuser = self.sess().query(User).filter(User.username==username).first()
-		dbuser.password = password
-		uid = dbuser.id
-		self.sess().commit()
-		self.invalidate_user_cache(uid, username)
+		dbuser.password = new_password
+		return ('ok', dbuser.id)
+
 	def set_bot(self, user_id, is_bot):
 		dbuser = self.sess().query(User).filter(User.id==user_id).first()
 		if dbuser:

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -2969,13 +2969,29 @@ class Protocol:
 			self.out_SERVERMSG(client, '%s' % reason)
 			return
 			
-		good, reason = self.userdb.check_login_user(client.username, cur_password)
-		if not good:
-			self.out_SERVERMSG(client, '%s' % reason)
-			return
+		# 3.1: re-verify the current password and write the new one off the reactor thread
+		# as one atomic DB unit. The callback (on the reactor) invalidates the 1.2 user
+		# cache and replies; it does no reactor-side DB, so it needs no session bracket.
+		d = self._root.defer_db(self.userdb.do_change_password, client.username, cur_password, new_password)
+		d.addCallback(self._changepassword_done, client)
+		d.addErrback(self._changepassword_failed, client)
 
-		self.userdb.set_user_password(client.username, new_password)
+	def _changepassword_done(self, verdict, client):
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB op
+		if verdict[0] == 'denied':
+			self.out_SERVERMSG(client, '%s' % verdict[1])
+			return
+		# verdict == ('ok', uid): the new password is committed; drop the stale cache entry
+		self.userdb.invalidate_user_cache(verdict[1], client.username)
 		self.out_SERVERMSG(client, 'Password changed successfully.')
+
+	def _changepassword_failed(self, failure, client):
+		# reactor-thread errback: a DB error means the password was not changed.
+		logging.error("CHANGEPASSWORD DB error for <%s>: %s" % (getattr(client, 'username', '?'), failure.getTraceback()))
+		if client.session_id not in self._root.clients:
+			return
+		self.out_SERVERMSG(client, "Server error processing CHANGEPASSWORD.")
 
 	def in_SETBOTMODE(self, client, username, mode):
 		# set bot mode of target user


### PR DESCRIPTION
Part of OPTIMIZATIONS.md 3.1 (async DB). Converts CHANGEPASSWORD so its credential
re-check and password write run off the reactor thread, the first slice of the
Account/verify handler group.

## Stacked on #16 — merge after it
This branch is stacked on `perf/phase3-async-mystatus-logout` (#16). Until #16 merges
to master, this PR's diff includes #16's commit; it narrows to just the CHANGEPASSWORD
commit once #16 lands. **Do not merge before #16** — see the race note below for why.

## Change
- New worker `SQLUsers.do_change_password(username, cur_pw, new_pw)`: re-verifies the
  current password and writes the new one as ONE uncommitted transaction (atomic
  check-then-set; `_run_db` owns the commit and the serialization-retry). Returns
  `('denied', reason)` without writing on a credential mismatch / vanished user, else
  `('ok', uid)`. Cache-free — no shared-state mutation on the worker thread.
- `in_CHANGEPASSWORD` keeps its two memory-only pre-checks (new != current,
  `_validPasswordSyntax`) on the reactor, then defers the worker.
- `_changepassword_done` (reactor callback): guards `session_id in clients`, invalidates
  the 1.2 user cache, replies. No reactor-side DB, so no session bracket. `_changepassword_failed`
  errback logs and replies; it mutates no shared state (the write didn't commit).
- Removed the now-orphaned synchronous `set_user_password` (its only caller was
  `in_CHANGEPASSWORD`), mirroring #16's removal of the orphaned `end_session`.

## Concurrency / race analysis
- **Concurrent password changes, same user:** last-write-wins, as before. Folding the
  credential check and the write into one worker transaction makes it atomic at the DB
  level (stronger than the old single-thread TOCTOU, never weaker). 1213/1205/1020 →
  `_run_db` retries from a fresh session.
- **Disconnect mid-write:** the off-reactor `users`-row UPDATE races the *synchronous*
  `end_session` logout cleanup (still on the reactor in `_remove`) on the same row,
  yielding a `1020 "record has changed"` that the synchronous path does not retry.
  CHANGEPASSWORD is the first converted handler to do an off-reactor `users`-row write
  while the client is fully logged in, so it is the first to expose this; the merged
  async LOGIN does not (the client isn't logged-in yet when its worker runs), and the
  friend/ignore/say conversions write other tables. **#16 fixes it** by deferring
  `end_session` through `_run_db`, whose retry loop absorbs the 1020. Verified on the
  stacked branch: CHANGEPASSWORD-then-immediate-drop produces 0 unhandled 1020s, vs ~27
  on master alone. This is why the PR is stacked on #16.
- **No shared in-memory state touched** beyond the 1.2 cache invalidation in the callback;
  `client.password` in memory was not updated by the old code either — preserved.

## Testing (MariaDB; the threaded path can't be exercised on sqlite)
- Worker-direct unit test: RED (AttributeError) → GREEN, plus a discrimination check
  (bypassing the credential gate makes the wrong-password assertions fail).
- E2E (server up): same-password rejected, malformed new password rejected, wrong
  current password rejected (DB unchanged), valid change persists AND the new password
  is usable for re-login while the old one is denied, 15-way concurrent independent
  changes all land correctly, and disconnect-during-call produces no unhandled errors on
  the stacked branch.

## Not converted (left for later slices of this group)
RENAMEACCOUNT, CHANGEEMAIL(REQUEST) + the verification deferral, RESETPASSWORD* /
RESENDVERIFICATION, and the admin DELETEACCOUNT / RESETUSERPASSWORD paths.