### PR TITLE
Run the RENAMEACCOUNT rename off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -717,22 +717,33 @@ class UsersHandler:
 			return ('taken',)
 		return ('ok', entry.id)
 
-	def rename_user(self, username, newname):
-		if newname == username:
-			return False, 'You already have that username.'
+	def do_rename_account(self, username, newname):
+		# 3.1 worker: PURE DB, ONE uncommitted transaction (_run_db owns the commit + retry).
+		# Replaces the old self-committing rename_user; returns verdict tuples and leaves cache
+		# invalidation to the reactor callback. The early uniqueness query is load-bearing for
+		# the case-insensitive
+		# collation behaviour: it matches the caller's OWN row on a case-only self-rename, so
+		# that is denied exactly as today (relying solely on the UNIQUE constraint would let a
+		# self-rename to a case variant succeed - a row's UPDATE never conflicts with itself).
+		# The IntegrityError catch handles the residual race where two concurrent renames both
+		# pass the early query: the UNIQUE(username) violation is 1062, which is NOT in _run_db's
+		# retry set, so we catch it here, roll back, and deny rather than retry a doomed write.
+		# The newname==username exact match is handled on the reactor before deferring.
 		results = self.sess().query(User).filter(User.username==newname).first()
 		if results:
-			return False, 'Username already exists.'
+			return ('denied', 'Username already exists.')
 		entry = self.sess().query(User).filter(User.username==username).first()
-		if not entry: 
-			return False, 'You don\'t seem to exist anymore. Contact an admin or moderator.'
-		entry.renames.append(Rename(username))
-		entry.username = newname
-		uid = entry.id
-		self.sess().commit()
-		self.invalidate_user_cache(uid, username)
-		self.invalidate_user_cache(username=newname)
-		return True, 'Account renamed successfully.'
+		if not entry:
+			return ('denied', 'You don\'t seem to exist anymore. Contact an admin or moderator.')
+		try:
+			entry.renames.append(Rename(username))
+			entry.username = newname
+			uid = entry.id
+			self.sess().flush() # force the UNIQUE check to fire HERE so 1062 is catchable
+		except IntegrityError:
+			self.sess().rollback()
+			return ('denied', 'Username already exists.')
+		return ('ok', uid, newname)
 
 	def save_user(self, obj):
 		# assert(isinstance(obj, User) or isinstance(obj, Client))

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -2948,14 +2948,39 @@ class Protocol:
 		if self.SayHooks.isNasty(newname):
 			self.out_FAILED(client, "RENAMEACCOUNT", "invalid nickname: %s" %(newname), True)
 			return
-			
-		good, reason = self.userdb.rename_user(client.username, newname)
-		if not good:
-			self.out_SERVERMSG(client, 'Failed to rename to <%s>: %s' % (newname, reason))
+		if newname == client.username:
+			self.out_SERVERMSG(client, 'Failed to rename to <%s>: %s' % (newname, 'You already have that username.'))
 			return
-		
+
+		# 3.1: free-check the newname and write the new username off the reactor thread as one
+		# atomic DB unit. The callback (on the reactor) invalidates the 1.2 user cache for both
+		# the old and new name, replies, and disconnects on success; it does no reactor-side DB,
+		# so it needs no session bracket.
+		d = self._root.defer_db(self.userdb.do_rename_account, client.username, newname)
+		d.addCallback(self._renameaccount_done, client, newname)
+		d.addErrback(self._renameaccount_failed, client, newname)
+
+	def _renameaccount_done(self, verdict, client, newname):
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB op
+		if verdict[0] == 'denied':
+			self.out_SERVERMSG(client, 'Failed to rename to <%s>: %s' % (newname, verdict[1]))
+			return
+		# verdict == ('ok', uid, newname): the new username is committed. Invalidate the 1.2 cache
+		# for BOTH names (old by id+name, new by name), mirroring rename_user, then notify and
+		# disconnect so the user reconnects under the new name. client.username is still the OLD
+		# name here (the rename does not mutate it in memory; the disconnect tears the client down).
+		self.userdb.invalidate_user_cache(verdict[1], client.username)
+		self.userdb.invalidate_user_cache(username=newname)
 		self.out_SERVERMSG(client, 'Your account has been renamed to <%s>. Reconnect with the new username (you will now be automatically disconnected).' % newname)
 		client.Remove('renaming')
+
+	def _renameaccount_failed(self, failure, client, newname):
+		# reactor-thread errback: a DB error means the rename did not happen.
+		logging.error("RENAMEACCOUNT DB error for <%s> -> <%s>: %s" % (getattr(client, 'username', '?'), newname, failure.getTraceback()))
+		if client.session_id not in self._root.clients:
+			return
+		self.out_SERVERMSG(client, "Server error processing RENAMEACCOUNT.")
 
 
 	def in_CHANGEPASSWORD(self, client, cur_password, new_password):


### PR DESCRIPTION
## OPTIMIZATIONS 3.1 — async RENAMEACCOUNT

Converts `in_RENAMEACCOUNT` to run its DB work off the reactor thread via `deferToThread`, following the established 3.1 pattern (`do_change_password` / `do_register_insert`).

### Stacked on #16 — merge after #16
This branch is stacked on `perf/phase3-async-mystatus-logout` (#16). **Do not merge before #16.** Until #16 lands on `master`, the diff shown here also includes #16's deferred-`end_session` change.

RENAMEACCOUNT writes the **users** row (username). On a disconnect mid-rename that off-reactor write races the synchronous `end_session` on the same row → unretried `1020 "Record has changed"`. #16 defers `end_session` through `_run_db`, whose retry loop absorbs the 1020. This slice depends on that fix.

### Changes
- **`do_rename_account` (worker, pure DB, one uncommitted transaction; `_run_db` owns commit + retry):** keeps the early uniqueness query — load-bearing for the case-insensitive collation (`utf8mb3_uca1400_ai_ci`): a case-only self-rename matches the caller's own row and is denied exactly as today; relying solely on the UNIQUE constraint would let a self-rename to a case variant succeed (a row's own UPDATE never conflicts with itself). Adds an `IntegrityError(1062)` catch for the residual two-renames-to-the-same-name race (1062 is deliberately **not** in the retry set). Returns verdict tuples; touches no shared state or caches.
- **`_renameaccount_done` (reactor callback):** guards `client.session_id in clients`, invalidates the 1.2 user cache for **both** old and new name, replies, and disconnects on success. No session bracket (cache invalidation is pure in-memory).
- **`_renameaccount_failed` (errback):** logs + generic SERVERMSG; no shared-state mutation.
- `newname == username` exact-match stays on the reactor (memory-only pre-check), alongside the `recent_renames` cap, syntax and `isNasty` checks — preserving ordering and user-facing messages.
- Removes the now-orphaned self-committing `rename_user` (its only caller was `in_RENAMEACCOUNT`).

### Verification (MariaDB, real thread pool)
- **Worker-unit:** happy path (`('ok', uid, newname)` + username persisted + `Rename` recorded), rename-to-taken denied, case-variant collision denied, case-only self-rename denied (collation-preservation), vanished-user denied, session reusable after denials. Discrimination check: removing the early query lets a case-only self-rename slip through and the test catches it.
- **E2E:** rename-to-self and rename-to-taken denials with exact messages + DB unchanged; valid rename persists the new username, records a `Rename`, frees the old name, keeps the same uid; concurrent rename-to-taken race yields exactly one DB winner + one denial.
- **Disconnect-mid-rename 1020 probe:** 0 unhandled 1020s on the stacked code. Positive control confirmed the probe really exercises the race: a synchronous no-retry `end_session` produced unhandled 1020s, and with the deferred path under a forced race window `_run_db` retried on 1020 and recovered every one to 0 unhandled.

### Races handled
- rename-to-taken (residual) → `IntegrityError(1062)` → denied, not retried.
- user vanished between pre-check and worker → denied.
- disconnect mid-rename (users-row write vs `end_session`) → absorbed by #16's deferred `end_session` retry.
- case-insensitive collation behaviour preserved via the early query.