### PR TITLE
Run the CHANGEEMAIL write off the reactor thread via deferToThread (OPTIMIZATIONS 3.1)

### DIFF
--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -765,6 +765,29 @@ class UsersHandler:
 		entry.ingame_time = ingame_time
 		return entry.id
 
+	def do_change_email(self, username, newmail):
+		# 3.1 worker: PURE DB, one uncommitted transaction (_run_db owns the commit + retry).
+		# CHANGEEMAIL only changes email, so we write ONLY that field rather than mirroring the
+		# all-field save_user: writing ingame_time/password/access here would clobber a value a
+		# concurrent handler (MYSTATUS's do_set_ingame_time, CHANGEPASSWORD) may have just written
+		# - the same clobber do_set_ingame_time avoids. users.email is UNIQUE, so the residual
+		# change-to-taken race that slips past the reactor pre-check surfaces as a 1062, which is
+		# NOT in _run_db's retry set; flush() forces it to fire HERE so we catch it, roll back,
+		# and deny rather than retry a doomed write. The verification gate stays on the reactor
+		# (it self-commits, so it can't live inside this single-transaction unit). Returns the
+		# user id for the reactor callback to invalidate the 1.2 cache with.
+		entry = self.sess().query(User).filter(User.username==username).first()
+		if entry is None:
+			return ('denied', 'You don\'t seem to exist anymore. Contact an admin or moderator.')
+		try:
+			entry.email = newmail
+			uid = entry.id
+			self.sess().flush() # force the UNIQUE check to fire HERE so 1062 is catchable
+		except IntegrityError:
+			self.sess().rollback()
+			return ('denied', "another user is already registered to the email address '%s'" % newmail)
+		return ('ok', uid, newmail)
+
 	def get_user_id_with_email(self, email):
 		if email == '':
 			return False, 'Email address is blank'

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -3447,10 +3447,35 @@ class Protocol:
 		if not good:
 			client.Send("CHANGEEMAILDENIED " + reason)
 			return
+
+		# 3.1: the verification gate stays on the reactor (it self-commits, so it can't be folded
+		# into the single-transaction worker). The users-row email write runs off the reactor as
+		# one atomic DB unit; the callback (on the reactor) sets the new email in memory, invalidates
+		# the 1.2 cache and replies. It does no reactor-side DB, so it needs no session bracket.
+		d = self._root.defer_db(self.userdb.do_change_email, client.username, newmail)
+		d.addCallback(self._changeemail_done, client, newmail)
+		d.addErrback(self._changeemail_failed, client, newmail)
+
+	def _changeemail_done(self, verdict, client, newmail):
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB op
+		if verdict[0] == 'denied':
+			client.Send("CHANGEEMAILDENIED " + verdict[1])
+			return
+		# verdict == ('ok', uid, newmail): the new email is committed. Set it in memory now (not
+		# before deferring, so a 1062 denial leaves no stale in-memory email), invalidate the 1.2
+		# cache by id+name (drops a stale offline snapshot carrying the old email), then notify.
 		client.email = newmail
-		self.userdb.save_user(client)
+		self.userdb.invalidate_user_cache(verdict[1], client.username)
 		self.out_SERVERMSG(client, "Your email address has been changed to " + client.email)
 		client.Send("CHANGEEMAILACCEPTED " + newmail)
+
+	def _changeemail_failed(self, failure, client, newmail):
+		# reactor-thread errback: a DB error means the email did not change.
+		logging.error("CHANGEEMAIL DB error for <%s> -> <%s>: %s" % (getattr(client, 'username', '?'), newmail, failure.getTraceback()))
+		if client.session_id not in self._root.clients:
+			return
+		self.out_SERVERMSG(client, "Server error processing CHANGEEMAIL.")
 
 	def in_RESETPASSWORDREQUEST(self, client, email):
 		# client requests to reset the pw of an account; account recovery by email


### PR DESCRIPTION
## What

Converts `in_CHANGEEMAIL`'s blocking users-row email write to run off the reactor thread via `deferToThread`, continuing the Phase 3.1 async-DB work. Branches off `master` (no longer stacked: #16, which fixes the `end_session` disconnect race, is merged).

## How

- **`SQLUsers.do_change_email`** — pure-DB worker, one uncommitted transaction owned by `_run_db` (it owns the commit + transient-error retry). Writes **only** the `email` field rather than mirroring the all-field `save_user`, so it can't clobber `ingame_time`/`password`/`access` that concurrent handlers (MYSTATUS's `do_set_ingame_time`, CHANGEPASSWORD) now own — the same clobber `do_set_ingame_time` avoids. `email` is `UNIQUE`, so the residual change-to-taken-email race that slips past the reactor pre-check surfaces as a `1062`; `flush()` forces it to fire inside the worker where it's caught, rolled back, and denied (1062 is not in `_run_db`'s retry set).
- **`in_CHANGEEMAIL`** — keeps the email-uniqueness pre-check and the `verificationdb.verify` gate on the reactor. `verify()` self-commits (attempts counter, code removal), so it cannot live inside the single-transaction worker; it also writes the *verifications* table, not the users row, and is not atomic with the email write today. Then defers the write.
- **`_changeemail_done`** (reactor callback) — guards `session_id in clients`, sets `client.email` in memory **only on success** (so a 1062 denial leaves no stale in-memory email), invalidates the 1.2 user cache by id+name, and sends the existing `CHANGEEMAILACCEPTED` + SERVERMSG strings. **`_changeemail_failed`** logs and replies with a generic message. No reactor-side DB in the callback, so no session bracket needed.
- `save_user` is left in place (DELETEACCOUNT, SETBOTMODE, RESETUSERPASSWORD, etc. still call it).

## Races

- **change-to-taken-email**: caught as `1062` in the worker → `('denied', ...)`.
- **user vanished** between pre-check and write: worker returns a denied verdict (fail-loud; the old `save_user` path silently no-op'd yet still sent ACCEPTED).
- **disconnect mid-write** (the `end_session` users-row race): fixed upstream by #16 (`end_session` is now a fresh-session retrying worker). Because both sides of the collision now read fresh sessions, the optimistic `1020` that CHANGEPASSWORD hit pre-#16 no longer arises for this writer.

## Testing (real MariaDB; sqlite forces `max_threads=1` and can't exercise the thread pool)

- Worker-unit: happy path, email-only write (ingame_time/access untouched), taken-email `1062` denial, self-email no-op, vanished user, retry-safety after denials. Plus a discrimination run (disabling the email write produced 5 failures incl. the 1062 path; restoring → PASS).
- E2E: functional (ACCEPTED + SERVERMSG + DB persist; taken → DENIED + unchanged), 12 concurrent independent changes all correct, and a change-to-taken **race** with a single genuine winner.
- Disconnect-mid-change probe: 0 unhandled 1020s / DB errors. Note: unlike #19 I could not construct a discriminating 1020 positive control for this writer — even with a forced window, the retry disabled, and `end_session` reverted to a synchronous reactor call, no 1020 occurred while both writers verifiably committed against the same rows. The 0 reflects fresh-session serialization, not a blind test.