### PR TITLE
Bound channel history reads, and a chat timestamp dialect

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -142,6 +142,11 @@ Clients advertise optional protocol capabilities via compatibility flags. Suppor
 | `u` | `say2` | `SAYFROM`; battle/channel unification of say commands |
 | `sp` | `scriptPassword` | scriptPassword included in `JOINEDBATTLE` |
 | `b` | `battleAuth` | `JOINBATTLEACCEPT` / `JOINBATTLEDENIED` (autohosts) — permanently optional |
+| `jsonchat` | `jsonChat` | Microsecond timestamps in JSON chat frames; `JSON SAIDPRIVATE` for queued offline messages — permanently optional |
+
+`jsonchat` is a progressive enhancement, not a gate: everything it covers still works
+without it, just with less information. See [Channel history](#61-channel-history-getchannelmessages)
+and [Offline direct messages](#82-offline-direct-messages).
 
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**
@@ -189,6 +194,61 @@ mute lists, topic, forwards. On join the server sends the joining client the mem
 **[GAP]** Full request/response listing for each channel command, including:
 `JOINED`/`LEFT` notifications, `CHANNELTOPIC` framing (and the now-mandatory timestamp),
 `SAID`/`SAIDEX` formats, channel-key (`SETCHANNELKEY`) semantics, ChanServ interactions.
+
+### 6.1 Channel history (`GETCHANNELMESSAGES`)
+
+```
+GETCHANNELMESSAGES <chanName> <lastMsgId>
+```
+
+Replays stored messages for a channel the client has already joined. History is **pull
+only** — the server sends no backlog on `JOIN`, so a client wanting it must ask.
+
+Storage is **opt-in per channel** (`store_history`, off by default) and only registered
+channels have it: an unregistered channel has id 0 and the command returns nothing.
+
+**`lastMsgId` is a cursor, not a timestamp.** Pass `0` for a cold start, or the highest
+`id` previously seen to resume. Messages are stored one insert at a time per channel, so
+the autoincrement `id` is monotonic with the order live users saw — which makes it a
+reliable resume token across a disconnect. Non-integer or negative values get
+`FAILED ... Invalid id`.
+
+The reply is a sequence of `JSON SAID` frames, oldest first, one per message:
+
+```
+JSON {"SAID":{"chanName":"foo","time":"1718200000","userName":"bob","msg":"hi","ex_msg":false,"id":42}}
+```
+
+| Field | Meaning |
+|---|---|
+| `chanName` | Channel the message was sent to |
+| `time` | Send time. **Dialect depends on `jsonchat`** — see below |
+| `userName` | Sender. Bridged users appear as `<externalName>:<location>`; a deleted account renders as `?` |
+| `msg` | Message body |
+| `ex_msg` | `true` if sent via `SAYEX` (an action rather than speech) |
+| `id` | Cursor value — the highest one seen is what to pass as `lastMsgId` next time |
+
+**Timestamp dialect:**
+
+| Client | `time` |
+|---|---|
+| with `jsonchat` | integer, unix **microseconds** (e.g. `1718200000123456`) |
+| without `jsonchat` | string, unix **seconds** (e.g. `"1718200000"`) |
+
+**Limits.** At most **200** messages are returned per call — the *newest* 200 after the
+cursor, not the oldest, so a cold-starting client gets recent context rather than the far
+end of the retention window. When older messages were elided, a `jsonchat` client is told
+so first:
+
+```
+JSON {"CHANNELMESSAGESTRUNCATED":{"chanName":"foo","oldestId":42}}
+```
+
+`oldestId` is the id of the oldest message in the batch that follows; anything between
+the client's cursor and that id was skipped. Clients without `jsonchat` cannot be told —
+the legacy dialect has no field for it — and simply receive the newest 200.
+
+Stored messages are deleted after **14 days**.
 
 ---
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -142,11 +142,11 @@ Clients advertise optional protocol capabilities via compatibility flags. Suppor
 | `u` | `say2` | `SAYFROM`; battle/channel unification of say commands |
 | `sp` | `scriptPassword` | scriptPassword included in `JOINEDBATTLE` |
 | `b` | `battleAuth` | `JOINBATTLEACCEPT` / `JOINBATTLEDENIED` (autohosts) — permanently optional |
-| `jsonchat` | `jsonChat` | Microsecond timestamps in JSON chat frames; `JSON SAIDPRIVATE` for queued offline messages — permanently optional |
+| `jsonchat` | `jsonChat` | Microsecond timestamps in JSON chat frames — permanently optional |
 
 `jsonchat` is a progressive enhancement, not a gate: everything it covers still works
-without it, just with less information. See [Channel history](#61-channel-history-getchannelmessages)
-and [Offline direct messages](#82-offline-direct-messages).
+without it, just with less information. See
+[Channel history](#61-channel-history-getchannelmessages).
 
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**

--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -1173,10 +1173,20 @@ class UsersHandler:
 		self.sess().commit()
 		return entry.id
 
-	def get_channel_messages(self, user_id, channel_id, last_msg_id):
-		# returns a list of channel messages since last_msg_id for the specific userid when he is subscribed to the channel
-		# [[date, username, msg, id], ...]
-		res = self.sess().query(ChannelHistory.time, ChannelHistory.msg, ChannelHistory.ex_msg, User.username, BridgedUser.external_username, BridgedUser.location, ChannelHistory.id).filter(ChannelHistory.channel_id == channel_id).filter(ChannelHistory.id > last_msg_id).join(User, isouter=True).join(BridgedUser, isouter=True).order_by(ChannelHistory.id).all()
+	def get_channel_messages(self, user_id, channel_id, last_msg_id, limit):
+		# returns (msgs, truncated) where msgs is [(date, username, msg, ex_msg, id), ...]
+		# after last_msg_id, oldest-first. user_id is unused (kept: existing signature).
+		#
+		# Takes the NEWEST limit rows rather than the oldest: a client resuming from
+		# last_msg_id=0 wants recent context, and handing it the oldest rows of the 14 day
+		# retention window would be useless. A client resuming after a short disconnect is
+		# under the cap either way, so the cap only bites on a cold start. Fetching limit+1
+		# probes for more without a second COUNT: getting more than limit back means older
+		# messages were elided, reported so the caller can say so instead of truncating silently.
+		res = self.sess().query(ChannelHistory.time, ChannelHistory.msg, ChannelHistory.ex_msg, User.username, BridgedUser.external_username, BridgedUser.location, ChannelHistory.id).filter(ChannelHistory.channel_id == channel_id).filter(ChannelHistory.id > last_msg_id).join(User, isouter=True).join(BridgedUser, isouter=True).order_by(ChannelHistory.id.desc()).limit(limit + 1).all()
+		truncated = len(res) > limit
+		res = res[:limit]
+		res.reverse()
 		msgs = []
 		for (htime, msg, ex_msg, username, external_username, location, id) in res:
 			if not username:
@@ -1185,8 +1195,8 @@ class UsersHandler:
 				bridged_username = external_username + ":" + location
 				msgs.append((htime, bridged_username, msg, ex_msg, id))
 			else:
-				msgs.append((htime, username, msg, ex_msg, id))				
-		return msgs
+				msgs.append((htime, username, msg, ex_msg, id))
+		return (msgs, truncated)
 
 class OfflineBridgedClient():
 	def __init__(self, sqluser):
@@ -2014,13 +2024,29 @@ if __name__ == '__main__':
 	assert(last_msg_id > -1)
 
 	for i in range(0,21):
-		msgs = userdb.get_channel_messages(channel.id, client.id, last_msg_id + i -1)
+		# NB: user_id/channel_id were passed the wrong way round here before the limit was
+		# added. It passed only because user_id is unused and a fresh db gives the first
+		# user and the first channel the same id, so the channel_id filter matched anyway.
+		msgs, truncated = userdb.get_channel_messages(client.id, channel.id, last_msg_id + i -1, 200)
 		assert(len(msgs) == 20 - i)
+		assert(truncated == False)
 		if (len(msgs) > 0):
 			assert(msgs[0][0] == now + timedelta(0, i))
 			assert(msgs[0][1] == client.username)
 			assert(msgs[0][2] == msg % i)
 			assert(type(msgs[0][2]) == str)
+
+	# the read cap returns the NEWEST messages, oldest-first, and reports the truncation
+	msgs, truncated = userdb.get_channel_messages(client.id, channel.id, last_msg_id - 1, 5)
+	assert(truncated == True)
+	assert(len(msgs) == 5)
+	assert(msgs[0][2] == msg % 15) # newest 5 of 20, not the oldest 5
+	assert(msgs[4][2] == msg % 19)
+
+	# a cap exactly matching the available rows is not a truncation
+	msgs, truncated = userdb.get_channel_messages(client.id, channel.id, last_msg_id - 1, 20)
+	assert(len(msgs) == 20)
+	assert(truncated == False)
 
 	userdb.add_channel_message(channel.id, None, None, "test", False)
 	userdb.add_channel_message(channel.id, 99, None, "test", False)

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -192,10 +192,12 @@ flag_map = {
 	'u':  'say2',            # SAYFROM, Battle<->Channel unification
 	'sp': 'scriptPassword',  # scriptPassword in JOINEDBATTLE
 	'b':  'battleAuth',      # JOINBATTLEACCEPT/JOINBATTLEDENIED (typically only sent by autohosts)
+	'jsonchat': 'jsonChat',  # microsecond timestamps in JSON chat frames, JSON SAIDPRIVATE
 }
 # optional flags
 optional_flags = (
 	'b', # only useful to autohosts -> permanently optional
+	'jsonchat', # progressive enhancement: without it chat still works, just without timestamps
 )
 
 # flags for functionality that is now either compulsory or was removed
@@ -1651,6 +1653,10 @@ class Protocol:
 	# GETCHANNELMESSAGES catch-up matches what live users saw.
 	_channel_store_max = 10000 # per-channel backlog cap; only reached if the DB stalls badly
 
+	# GETCHANNELMESSAGES read cap: the newest N messages after the client's cursor. Without
+	# this a client passing last_msg_id=0 on a busy channel pulls the whole 14 day window.
+	_channel_history_max_fetch = 200
+
 	def _enqueue_channel_store(self, channel, user_id, bridged_id, msg, ex_msg):
 		# reactor thread only. Append the store and kick the pump if idle.
 		if len(channel.history_queue) >= self._channel_store_max:
@@ -2555,25 +2561,32 @@ class Protocol:
 			self.out_FAILED(client, "GETCHANNELMESSAGES", "Can't get channel messages when not joined", True)
 			return
 		try:
-			datetime.datetime.fromtimestamp(int(last_msg_id))
-		except:
+			last_msg_id = int(last_msg_id)
+			if last_msg_id < 0:
+				raise ValueError
+		except ValueError:
 			self.out_FAILED(client, "GETCHANNELMESSAGES", "Invalid id", True)
 			return
 		# 3.1: read channel history off the reactor thread. The worker returns plain
 		# [(datetime, username, msg, ex_msg, id), ...] - usernames are resolved inside the
 		# query (joins to User/BridgedUser), so the callback does NO reactor-side DB and
 		# needs no session bracket; it just formats + sends. A pure read, so no new races.
-		d = self._root.defer_db(self.userdb.get_channel_messages, client.user_id, channel.id, last_msg_id)
+		d = self._root.defer_db(self.userdb.get_channel_messages, client.user_id, channel.id, last_msg_id, self._channel_history_max_fetch)
 		d.addCallback(self._channelmessages_send, client, chan)
 		d.addErrback(self._channelmessages_failed, client)
 
-	def _channelmessages_send(self, msgs, client, chan):
+	def _channelmessages_send(self, result, client, chan):
 		# reactor-thread callback: pure send, no DB -> no commit/rollback/close bracket.
 		if client.session_id not in self._root.clients:
 			return # client disconnected during the DB call
+		msgs, truncated = result
+		rich = 'jsonchat' in client.compat
+		if truncated and rich:
+			# older messages were elided by the read cap. Only jsonchat clients can be told:
+			# the legacy dialect has no field for it, so they silently get the newest N.
+			self.out_JSON(client, 'CHANNELMESSAGESTRUNCATED', {"chanName": chan, "oldestId": msgs[0][4]})
 		for msg in msgs:
-			timestamp = int(time.mktime(msg[0].timetuple()))
-			self.out_JSON(client,  'SAID', {"chanName": chan, "time": str(timestamp), "userName": msg[1], "msg": msg[2], "ex_msg":msg[3], "id": msg[4]})
+			self.out_JSON(client, 'SAID', {"chanName": chan, "time": self._chat_timestamp(msg[0], rich), "userName": msg[1], "msg": msg[2], "ex_msg": msg[3], "id": msg[4]})
 
 	def _channelmessages_failed(self, failure, client):
 		# reactor-thread errback: a DB error fetching history. Log it loudly; unlike the
@@ -3877,6 +3890,15 @@ class Protocol:
 
 	def out_JSON(self, client, cmd, dict):
 		client.Send('JSON ' + json.dumps({cmd: dict}, separators=(',', ':')))
+
+	def _chat_timestamp(self, dt, rich):
+		# Dual-dialect timestamp for JSON chat frames. jsonchat clients get an integer of
+		# unix microseconds (tachyon's unixTime convention); clients without the flag keep
+		# the original string-of-unix-seconds, because handing an existing JSON SAID parser
+		# a value a million times too large fails silently rather than loudly.
+		if rich:
+			return int(dt.timestamp()) * 1000000 + dt.microsecond
+		return str(int(time.mktime(dt.timetuple())))
 
 def check_protocol_commands():
 	for command in restricted_list:

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -192,7 +192,7 @@ flag_map = {
 	'u':  'say2',            # SAYFROM, Battle<->Channel unification
 	'sp': 'scriptPassword',  # scriptPassword in JOINEDBATTLE
 	'b':  'battleAuth',      # JOINBATTLEACCEPT/JOINBATTLEDENIED (typically only sent by autohosts)
-	'jsonchat': 'jsonChat',  # microsecond timestamps in JSON chat frames, JSON SAIDPRIVATE
+	'jsonchat': 'jsonChat',  # microsecond timestamps in JSON chat frames
 }
 # optional flags
 optional_flags = (

--- a/tests/integration/channelmsgtest.py
+++ b/tests/integration/channelmsgtest.py
@@ -46,12 +46,13 @@ class Sock:
                 self.buf += chunk.decode(errors="replace")
         except socket.timeout:
             pass
-    def collect_said(self, chan, want, timeout=4.0):
-        # GETCHANNELMESSAGES has no end marker; collect `want` SAID lines for `chan`
-        # or give up after `timeout`. Returns list of (id, userName, msg, ex_msg) in
-        # arrival order.
+    def collect_said_raw(self, chan, want, timeout=8.0):
+        # GETCHANNELMESSAGES has no end marker; collect `want` SAID frames for `chan` or
+        # give up after `timeout`. Returns (said_dicts, other_frames) where other_frames
+        # holds any non-SAID JSON frames seen along the way (e.g. the truncation notice).
         deadline = time.time() + timeout
         got = []
+        others = []
         while len(got) < want and time.time() < deadline:
             self.s.settimeout(max(0.05, deadline - time.time()))
             try:
@@ -72,10 +73,18 @@ class Sock:
                 except Exception:
                     continue
                 said = obj.get("SAID")
-                if not said or said.get("chanName") != chan:
+                if said is None:
+                    others.append(obj)
                     continue
-                got.append((int(said["id"]), said["userName"], said["msg"], said["ex_msg"]))
-        return got
+                if said.get("chanName") != chan:
+                    continue
+                got.append(said)
+        return got, others
+
+    def collect_said(self, chan, want, timeout=4.0):
+        # arrival-order (id, userName, msg, ex_msg) tuples
+        said, _ = self.collect_said_raw(chan, want, timeout)
+        return [(int(m["id"]), m["userName"], m["msg"], m["ex_msg"]) for m in said]
     def close(self):
         try: self.s.close()
         except: pass
@@ -97,9 +106,13 @@ def register_and_confirm(user):
     s.close()
     return ok
 
-def login_keep(user):
+def login_keep(user, compat=None):
+    # compat flags ride in the login sentence: "<agent>\t<last_id>\t<flags>"
     s = connect()
-    s.sendall(("LOGIN %s %s 0 * TestClient\n" % (user, PW)).encode())
+    if compat:
+        s.sendall(("LOGIN %s %s 0 * TestClient\t0\t%s\n" % (user, PW, compat)).encode())
+    else:
+        s.sendall(("LOGIN %s %s 0 * TestClient\n" % (user, PW)).encode())
     resp = recv_until(s, "LOGININFOEND", timeout=8)
     if "ACCEPTED" not in resp or "LOGININFOEND" not in resp:
         s.close()
@@ -199,6 +212,108 @@ if sk is not None:
     else:
         print("WARN: invalid last_msg_id did not yield expected FAILED (buf tail: %r)" % sk.buf[-200:])
     sk.close()
+
+# ---------- read cap: newest-N, truncation signal, timestamp dialects ----------
+# Seeded AFTER the checks above so their exact-count assertions are unaffected.
+CAP = 200
+EXTRA = 205  # push the channel past the cap
+conn = pymysql.connect(**DB)
+cur = conn.cursor()
+seed_time = "2030-01-01 00:00:00"  # distinctive + stable: lets us pin the exact timestamp
+rows = [(chan_id, A[0], None, seed_time, "cap%d" % i, 0) for i in range(EXTRA)]
+cur.executemany(
+    "INSERT INTO channel_history (channel_id, user_id, bridged_id, time, msg, ex_msg) VALUES (%s,%s,%s,%s,%s,%s)",
+    rows)
+conn.close()
+print("seeded %d extra rows to exceed the %d cap" % (EXTRA, CAP))
+
+# expected microsecond value for seed_time, computed the same way the server does
+# (naive datetime -> local epoch), so this pins the dialect without hardcoding a TZ.
+import datetime as _dt
+_seed_dt = _dt.datetime(2030, 1, 1, 0, 0, 0)
+EXPECT_US = int(_seed_dt.timestamp()) * 1000000
+EXPECT_SEC = str(int(time.mktime(_seed_dt.timetuple())))
+
+def check_cap(user, compat, label):
+    sk = login_keep(user, compat)
+    if sk is None:
+        errors.append("%s: login failed" % label); return None
+    try:
+        sk.send("JOIN %s" % CHAN)
+        sk.drain(0.6)
+        sk.send("GETCHANNELMESSAGES %s 0" % CHAN)
+        said, others = sk.collect_said_raw(CHAN, CAP)
+        if len(said) != CAP:
+            errors.append("%s: got %d SAID, want exactly %d (cap)" % (label, len(said), CAP))
+            return None
+        # newest-N, not oldest-N: the last seeded row must be present, the first must not
+        msgs = [m["msg"] for m in said]
+        if msgs[-1] != "cap%d" % (EXTRA - 1):
+            errors.append("%s: newest message is %r, want %r" % (label, msgs[-1], "cap%d" % (EXTRA - 1)))
+        if "m0" in msgs:
+            errors.append("%s: oldest message m0 present - returned oldest-N not newest-N" % label)
+        ids = [int(m["id"]) for m in said]
+        if ids != sorted(ids):
+            errors.append("%s: ids not ascending" % label)
+        return said, others
+    finally:
+        sk.close()
+
+def report(label, before):
+    # print PASS only if this section actually added no errors, else print what broke
+    new = errors[before:]
+    if new:
+        print("FAIL: %s" % label)
+        for e in new:
+            print("  ", e)
+    else:
+        print("PASS: %s" % label)
+
+# legacy client: string-of-seconds, and no truncation frame (it has no field for one)
+n = len(errors)
+r = check_cap(viewers[1], None, "legacy")
+if r:
+    said, others = r
+    t = said[-1]["time"]
+    if not (isinstance(t, str) and t == EXPECT_SEC):
+        errors.append("legacy: time=%r (%s), want str %r" % (t, type(t).__name__, EXPECT_SEC))
+    if any("CHANNELMESSAGESTRUNCATED" in o for o in others):
+        errors.append("legacy: got a truncation frame it cannot parse")
+report("legacy dialect -> string seconds, no truncation frame", n)
+
+# jsonchat client: integer microseconds + an explicit truncation notice
+n = len(errors)
+r = check_cap(viewers[2], "jsonchat", "jsonchat")
+if r:
+    said, others = r
+    t = said[-1]["time"]
+    if not (isinstance(t, int) and t == EXPECT_US):
+        errors.append("jsonchat: time=%r (%s), want int %r" % (t, type(t).__name__, EXPECT_US))
+    trunc = [o["CHANNELMESSAGESTRUNCATED"] for o in others if "CHANNELMESSAGESTRUNCATED" in o]
+    if not trunc:
+        errors.append("jsonchat: no truncation frame despite %d rows > %d cap" % (EXTRA, CAP))
+    elif trunc[0].get("oldestId") != int(said[0]["id"]):
+        errors.append("jsonchat: truncation oldestId=%r, want %r" % (trunc[0].get("oldestId"), said[0]["id"]))
+report("jsonchat dialect -> int microseconds + truncation notice", n)
+
+# a cursor near the head must NOT report truncation (the cap only bites on a cold start)
+n = len(errors)
+sk = login_keep(viewers[3], "jsonchat")
+if sk is not None:
+    sk.send("JOIN %s" % CHAN)
+    sk.drain(0.6)
+    conn = pymysql.connect(**DB); cur = conn.cursor()
+    cur.execute("SELECT MAX(id) FROM channel_history WHERE channel_id=%s", (chan_id,))
+    max_id = cur.fetchone()[0]
+    conn.close()
+    sk.send("GETCHANNELMESSAGES %s %d" % (CHAN, max_id - 3))
+    said, others = sk.collect_said_raw(CHAN, 3, timeout=3.0)
+    if len(said) != 3:
+        errors.append("resume: got %d SAID, want 3" % len(said))
+    elif any("CHANNELMESSAGESTRUNCATED" in o for o in others):
+        errors.append("resume: truncation reported for a 3-message catch-up under the cap")
+    sk.close()
+report("short resume returns 3 messages, no truncation", n)
 
 # ---------- disconnect-during-call check ----------
 dropped = 0


### PR DESCRIPTION
## Why

Two problems with `GETCHANNELMESSAGES`, found while looking at what it would take to give lobbies a chat backlog. It turned out most of the machinery already exists (the `channel_history` table, the `store_history` opt-in, the serialized write path, the `id` cursor) — so this is a fix-and-document pass, not a new feature.

**1. The read was unbounded.** No `LIMIT`. A client passing `last_msg_id=0` on a busy channel pulls the entire 14 day retention window in one reply. Capped at 200.

The cap takes the **newest** 200 after the cursor, not the oldest. Ordering the other way would hand a joining client the oldest 200 messages of a fortnight, which is useless to it — a cold start wants recent context. A client resuming after a dropped connection is under the cap either way, so the cap only bites on a cold start, which is exactly where it should.

**2. The id validation was nonsense.** It ran `datetime.fromtimestamp(int(last_msg_id))` on a *message id* — vestigial from a time-based API, and it only ever passed because any integer in range happens to parse as a date. Now checks for a non-negative int. Same `FAILED ... Invalid id` reply, so well-formed input sees no change.

## Truncation is reported, not silent

The query fetches `limit + 1` as a probe: getting more than `limit` back means older messages were elided. That avoids a second `COUNT` over the same window.

When it fires, a `jsonchat` client gets `JSON CHANNELMESSAGESTRUNCATED` with the `oldestId` of the batch that follows, so it knows there is a hole rather than assuming it has everything. This is the one idea worth taking from tachyon, whose `subscribeReceived` carries `hasMissedMessages` for the same reason. Clients without the flag can't be told — the legacy dialect has no field for it — and quietly get the newest 200.

## The `jsonchat` flag

New opt-in flag. Timestamps in JSON chat frames become an integer of unix **microseconds** (tachyon's `unixTime` convention) instead of a string of seconds.

Migrating the field outright wasn't an option: an existing `JSON SAID` parser handed a value 1e6 too large doesn't error, it renders as the year 57000. So the dialects run side by side, gated on the flag, the way `in_SAY` already sends `SAID` twice via `flag='u'` / `not_flag='u'`.

It is registered in **both** `flag_map` and `optional_flags`. Anything in `flag_map` but not `optional_flags` is treated as mandatory, and `_checkCompat` would then make every existing client log a compatibility warning for not implementing something optional.

Note the `DATETIME` columns store whole seconds, so these are microsecond-*unit*, second-*precision*. That is the unit tachyon specifies and is ample for ordering and display; sub-second would need `DATETIME(6)` and therefore an `ALTER` on live deployments.

## Not addressed

- `store_history` still defaults to off, so most channels have no backlog. That's a policy call, not a bug.
- Unregistered channels (`id == 0`) still get no history.
- No auto-push of backlog on join — this stays pull-only.

## Incidentally

The `SQLUsers.py` self-test passed `user_id`/`channel_id` to `get_channel_messages` the wrong way round. It only passed because `user_id` is unused *and* a fresh CI db gives the first user and first channel the same id, so the filter matched by coincidence. Corrected while updating the call for the new signature.

## Verification

Full suite against MariaDB: **21 passed, 1 failed** — the failure is the known `renameaccounttest` harness bug (it opens `server.log` relative to its own directory), identical on master.

e2e coverage seeds past the cap and asserts newest-N, the truncation notice and its `oldestId`, that a short resume reports no truncation, and both dialects side by side from the same rows. Each was discrimination-checked — breaking newest-N, removing the `LIMIT`, and forcing the legacy dialect each fail the specific assertion that should catch them.