### PR TITLE
Offline direct messages

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -142,11 +142,11 @@ Clients advertise optional protocol capabilities via compatibility flags. Suppor
 | `u` | `say2` | `SAYFROM`; battle/channel unification of say commands |
 | `sp` | `scriptPassword` | scriptPassword included in `JOINEDBATTLE` |
 | `b` | `battleAuth` | `JOINBATTLEACCEPT` / `JOINBATTLEDENIED` (autohosts) — permanently optional |
-| `jsonchat` | `jsonChat` | Microsecond timestamps in JSON chat frames — permanently optional |
+| `jsonchat` | `jsonChat` | Microsecond timestamps in JSON chat frames; `JSON SAIDPRIVATE` for queued offline messages — permanently optional |
 
 `jsonchat` is a progressive enhancement, not a gate: everything it covers still works
-without it, just with less information. See
-[Channel history](#61-channel-history-getchannelmessages).
+without it, just with less information. See [Channel history](#61-channel-history-getchannelmessages)
+and [Offline direct messages](#82-offline-direct-messages).
 
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -282,6 +282,56 @@ bots, script_tags, startrects, map/mod/engine, player/spectator limits.
 These are uberserver additions not present in base upstream. **[GAP]** full
 request/response grammar and the notifications each produces.
 
+### 8.2 Offline direct messages
+
+`SAYPRIVATE` / `SAYPRIVATEEX` to a user who is **not online** are queued and delivered
+the next time that user logs in, rather than dropped.
+
+Queueing is unconditional and needs no flag, so this works on every lobby. What the
+`jsonchat` flag buys is the *timestamp*: without it there is nowhere in `SAIDPRIVATE`
+to put the original send time, so an old client receives the queued messages as a burst
+that looks like it just arrived.
+
+**Sending.** The sender gets the usual echo (`SAYPRIVATE <user> <msg>`) and is *not*
+told whether the message was delivered live or stored — the two cases are deliberately
+indistinguishable. Exceptions:
+
+| Case | Result |
+|---|---|
+| Recipient is a **bot** | `FAILED` — bots never receive offline messages, so a queue of commands cannot flood an autohost at login |
+| Recipient does not exist | Silently ignored (unchanged behaviour) |
+| Recipient **ignores** the sender | Echoed as if sent; nothing is stored. Ignore status is not detectable by probing |
+| Server/db error | `FAILED`, and nothing is echoed — a queued message is never implied when the write failed |
+
+**Delivery.** On login, after `LOGININFOEND`:
+
+| Client | Frame |
+|---|---|
+| with `jsonchat` | `JSON {"SAIDPRIVATE":{"userName":"bob","msg":"hi","ex_msg":false,"time":1718200000000000}}` |
+| without | `SAIDPRIVATE bob hi` — no timestamp, delivered as a burst |
+
+`time` is the **original send time** in unix microseconds, not the delivery time.
+`SAYPRIVATEEX` round-trips as `SAIDPRIVATEEX` / `ex_msg: true`.
+
+Delivered messages are deleted immediately. Delivery is **at-most-once**: sends are
+buffered and unacknowledged, so a disconnect mid-delivery can lose them.
+
+**Limits and expiry.** A sender may hold at most **50** queued messages for any one
+recipient, and content is dropped after **14 days** (the same window `channel_history`
+uses — private content is not held longer than public chat).
+
+Neither limit discards anything silently. Whenever content is dropped, a **tombstone**
+survives it: the recipient is still told that someone tried to reach them, so they can
+ask rather than never finding out. One tombstone per sender, counting everything lost:
+
+| Client | Frame |
+|---|---|
+| with `jsonchat` | `JSON {"OFFLINEMESSAGESDROPPED":{"userName":"bob","count":7,"time":1718200000000000}}` |
+| without | `SERVERMSG bob sent you 7 message(s) while you were away, but they expired...` |
+
+`time` is the newest lost message's send time. Tombstones do not expire — they persist
+until delivered, then are deleted like any other queued message.
+
 ---
 
 ## 9. Bridged clients

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -142,6 +142,11 @@ Clients advertise optional protocol capabilities via compatibility flags. Suppor
 | `u` | `say2` | `SAYFROM`; battle/channel unification of say commands |
 | `sp` | `scriptPassword` | scriptPassword included in `JOINEDBATTLE` |
 | `b` | `battleAuth` | `JOINBATTLEACCEPT` / `JOINBATTLEDENIED` (autohosts) — permanently optional |
+| `jsonchat` | `jsonChat` | Microsecond timestamps in JSON chat frames; `JSON SAIDPRIVATE` for queued offline messages — permanently optional |
+
+`jsonchat` is a progressive enhancement, not a gate: everything it covers still works
+without it, just with less information. See [Channel history](#61-channel-history-getchannelmessages)
+and [Offline direct messages](#82-offline-direct-messages).
 
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**
@@ -189,6 +194,61 @@ mute lists, topic, forwards. On join the server sends the joining client the mem
 **[GAP]** Full request/response listing for each channel command, including:
 `JOINED`/`LEFT` notifications, `CHANNELTOPIC` framing (and the now-mandatory timestamp),
 `SAID`/`SAIDEX` formats, channel-key (`SETCHANNELKEY`) semantics, ChanServ interactions.
+
+### 6.1 Channel history (`GETCHANNELMESSAGES`)
+
+```
+GETCHANNELMESSAGES <chanName> <lastMsgId>
+```
+
+Replays stored messages for a channel the client has already joined. History is **pull
+only** — the server sends no backlog on `JOIN`, so a client wanting it must ask.
+
+Storage is **opt-in per channel** (`store_history`, off by default) and only registered
+channels have it: an unregistered channel has id 0 and the command returns nothing.
+
+**`lastMsgId` is a cursor, not a timestamp.** Pass `0` for a cold start, or the highest
+`id` previously seen to resume. Messages are stored one insert at a time per channel, so
+the autoincrement `id` is monotonic with the order live users saw — which makes it a
+reliable resume token across a disconnect. Non-integer or negative values get
+`FAILED ... Invalid id`.
+
+The reply is a sequence of `JSON SAID` frames, oldest first, one per message:
+
+```
+JSON {"SAID":{"chanName":"foo","time":"1718200000","userName":"bob","msg":"hi","ex_msg":false,"id":42}}
+```
+
+| Field | Meaning |
+|---|---|
+| `chanName` | Channel the message was sent to |
+| `time` | Send time. **Dialect depends on `jsonchat`** — see below |
+| `userName` | Sender. Bridged users appear as `<externalName>:<location>`; a deleted account renders as `?` |
+| `msg` | Message body |
+| `ex_msg` | `true` if sent via `SAYEX` (an action rather than speech) |
+| `id` | Cursor value — the highest one seen is what to pass as `lastMsgId` next time |
+
+**Timestamp dialect:**
+
+| Client | `time` |
+|---|---|
+| with `jsonchat` | integer, unix **microseconds** (e.g. `1718200000123456`) |
+| without `jsonchat` | string, unix **seconds** (e.g. `"1718200000"`) |
+
+**Limits.** At most **200** messages are returned per call — the *newest* 200 after the
+cursor, not the oldest, so a cold-starting client gets recent context rather than the far
+end of the retention window. When older messages were elided, a `jsonchat` client is told
+so first:
+
+```
+JSON {"CHANNELMESSAGESTRUNCATED":{"chanName":"foo","oldestId":42}}
+```
+
+`oldestId` is the id of the oldest message in the batch that follows; anything between
+the client's cursor and that id was skipped. Clients without `jsonchat` cannot be told —
+the legacy dialect has no field for it — and simply receive the newest 200.
+
+Stored messages are deleted after **14 days**.
 
 ---
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -142,11 +142,11 @@ Clients advertise optional protocol capabilities via compatibility flags. Suppor
 | `u` | `say2` | `SAYFROM`; battle/channel unification of say commands |
 | `sp` | `scriptPassword` | scriptPassword included in `JOINEDBATTLE` |
 | `b` | `battleAuth` | `JOINBATTLEACCEPT` / `JOINBATTLEDENIED` (autohosts) — permanently optional |
-| `jsonchat` | `jsonChat` | Microsecond timestamps in JSON chat frames; `JSON SAIDPRIVATE` for queued offline messages — permanently optional |
+| `jsonchat` | `jsonChat` | Microsecond timestamps in JSON chat frames — permanently optional |
 
 `jsonchat` is a progressive enhancement, not a gate: everything it covers still works
-without it, just with less information. See [Channel history](#61-channel-history-getchannelmessages)
-and [Offline direct messages](#82-offline-direct-messages).
+without it, just with less information. See
+[Channel history](#61-channel-history-getchannelmessages).
 
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**

--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -1173,10 +1173,20 @@ class UsersHandler:
 		self.sess().commit()
 		return entry.id
 
-	def get_channel_messages(self, user_id, channel_id, last_msg_id):
-		# returns a list of channel messages since last_msg_id for the specific userid when he is subscribed to the channel
-		# [[date, username, msg, id], ...]
-		res = self.sess().query(ChannelHistory.time, ChannelHistory.msg, ChannelHistory.ex_msg, User.username, BridgedUser.external_username, BridgedUser.location, ChannelHistory.id).filter(ChannelHistory.channel_id == channel_id).filter(ChannelHistory.id > last_msg_id).join(User, isouter=True).join(BridgedUser, isouter=True).order_by(ChannelHistory.id).all()
+	def get_channel_messages(self, user_id, channel_id, last_msg_id, limit):
+		# returns (msgs, truncated) where msgs is [(date, username, msg, ex_msg, id), ...]
+		# after last_msg_id, oldest-first. user_id is unused (kept: existing signature).
+		#
+		# Takes the NEWEST limit rows rather than the oldest: a client resuming from
+		# last_msg_id=0 wants recent context, and handing it the oldest rows of the 14 day
+		# retention window would be useless. A client resuming after a short disconnect is
+		# under the cap either way, so the cap only bites on a cold start. Fetching limit+1
+		# probes for more without a second COUNT: getting more than limit back means older
+		# messages were elided, reported so the caller can say so instead of truncating silently.
+		res = self.sess().query(ChannelHistory.time, ChannelHistory.msg, ChannelHistory.ex_msg, User.username, BridgedUser.external_username, BridgedUser.location, ChannelHistory.id).filter(ChannelHistory.channel_id == channel_id).filter(ChannelHistory.id > last_msg_id).join(User, isouter=True).join(BridgedUser, isouter=True).order_by(ChannelHistory.id.desc()).limit(limit + 1).all()
+		truncated = len(res) > limit
+		res = res[:limit]
+		res.reverse()
 		msgs = []
 		for (htime, msg, ex_msg, username, external_username, location, id) in res:
 			if not username:
@@ -1185,8 +1195,8 @@ class UsersHandler:
 				bridged_username = external_username + ":" + location
 				msgs.append((htime, bridged_username, msg, ex_msg, id))
 			else:
-				msgs.append((htime, username, msg, ex_msg, id))				
-		return msgs
+				msgs.append((htime, username, msg, ex_msg, id))
+		return (msgs, truncated)
 
 class OfflineBridgedClient():
 	def __init__(self, sqluser):
@@ -2014,13 +2024,29 @@ if __name__ == '__main__':
 	assert(last_msg_id > -1)
 
 	for i in range(0,21):
-		msgs = userdb.get_channel_messages(channel.id, client.id, last_msg_id + i -1)
+		# NB: user_id/channel_id were passed the wrong way round here before the limit was
+		# added. It passed only because user_id is unused and a fresh db gives the first
+		# user and the first channel the same id, so the channel_id filter matched anyway.
+		msgs, truncated = userdb.get_channel_messages(client.id, channel.id, last_msg_id + i -1, 200)
 		assert(len(msgs) == 20 - i)
+		assert(truncated == False)
 		if (len(msgs) > 0):
 			assert(msgs[0][0] == now + timedelta(0, i))
 			assert(msgs[0][1] == client.username)
 			assert(msgs[0][2] == msg % i)
 			assert(type(msgs[0][2]) == str)
+
+	# the read cap returns the NEWEST messages, oldest-first, and reports the truncation
+	msgs, truncated = userdb.get_channel_messages(client.id, channel.id, last_msg_id - 1, 5)
+	assert(truncated == True)
+	assert(len(msgs) == 5)
+	assert(msgs[0][2] == msg % 15) # newest 5 of 20, not the oldest 5
+	assert(msgs[4][2] == msg % 19)
+
+	# a cap exactly matching the available rows is not a truncation
+	msgs, truncated = userdb.get_channel_messages(client.id, channel.id, last_msg_id - 1, 20)
+	assert(len(msgs) == 20)
+	assert(truncated == False)
 
 	userdb.add_channel_message(channel.id, None, None, "test", False)
 	userdb.add_channel_message(channel.id, 99, None, "test", False)

--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -13,7 +13,7 @@ import _thread as thread
 
 	
 try:
-	from sqlalchemy import Table, Column, Integer, String, MetaData, ForeignKey, Boolean, Text, DateTime, UniqueConstraint
+	from sqlalchemy import Table, Column, Integer, String, MetaData, ForeignKey, Boolean, Text, DateTime, UniqueConstraint, Index
 	from sqlalchemy.orm import mapper, sessionmaker, relation, scoped_session
 	from sqlalchemy.exc import IntegrityError
 except ImportError as e:
@@ -25,6 +25,13 @@ except ImportError as e:
 
 
 metadata = MetaData()
+
+# Offline direct messages. The TTL matches channel_history's retention: the server holds
+# private message content for as long as it holds public chat, and no longer. Past that
+# the content is dropped and only a contentless tombstone survives, so a returning user
+# still learns someone tried to reach them.
+OFFLINE_MSG_TTL_DAYS = 14
+OFFLINE_MSG_MAX_PER_PAIR = 50 # queued content messages one sender may hold for one recipient
 ##########################################
 users_table = Table('users', metadata,
 	Column('id', Integer, primary_key=True),
@@ -275,6 +282,40 @@ class ChannelHistory(object):
 	def __repr__(self):
 		return "<ChannelHistory('%s')>" % self.channel_id
 mapper(ChannelHistory, channelshistory_table)
+##########################################
+# Direct messages sent to a user who was offline, held until they next log in and then
+# deleted. Content is transient by design: it is dropped after OFFLINE_MSG_TTL_DAYS, or
+# when a sender exceeds OFFLINE_MSG_MAX_PER_PAIR queued messages for one recipient.
+#
+# A row with msg IS NULL is a TOMBSTONE: the content is gone but the recipient is still
+# told that someone tried to reach them, so they know to ask rather than never finding
+# out. There is at most one tombstone per (sender, recipient) pair - dropped_count says
+# how many messages it stands for and time is the newest one's send time. Without that
+# collapse, 50 expiring messages would become 50 tombstones.
+offlinemessages_table = Table('offline_messages', metadata,
+	Column('id', Integer, primary_key=True),
+	Column('sender_user_id', Integer, ForeignKey('users.id', onupdate='CASCADE', ondelete='CASCADE')),
+	Column('recipient_user_id', Integer, ForeignKey('users.id', onupdate='CASCADE', ondelete='CASCADE')),
+	Column('time', DateTime),
+	Column('msg', Text, nullable=True), # NULL == tombstone
+	Column('ex_msg', Boolean),
+	Column('dropped_count', Integer, default=0), # only meaningful on a tombstone
+	Index('ix_offline_messages_recipient', 'recipient_user_id', 'id'), # login fetch
+	Index('ix_offline_messages_pair', 'sender_user_id', 'recipient_user_id'), # per-pair cap count
+	mysql_charset='utf8',
+	)
+class OfflineMessage(object):
+	def __init__(self, sender_user_id, recipient_user_id, time, msg, ex_msg, dropped_count=0):
+		self.sender_user_id = sender_user_id
+		self.recipient_user_id = recipient_user_id
+		self.time = time
+		self.msg = msg
+		self.ex_msg = ex_msg
+		self.dropped_count = dropped_count
+
+	def __repr__(self):
+		return "<OfflineMessage(%s -> %s, %s)>" % (self.sender_user_id, self.recipient_user_id, "tombstone" if self.msg is None else "content")
+mapper(OfflineMessage, offlinemessages_table)
 ##########################################
 channelops_table = Table('channel_ops', metadata,
 	Column('id', Integer, primary_key=True),
@@ -1164,6 +1205,75 @@ class UsersHandler:
 		# tolerant DELETE (no .one(), unlike unignore_user) so a duplicate row from the
 		# no-unique-constraint race cannot raise MultipleResultsFound and can never be orphaned.
 		self.sess().query(Ignore).filter(Ignore.user_id == user_id).filter(Ignore.ignored_user_id == unignore_user_id).delete()
+
+	# --- offline direct messages (cache-free workers; see the offline_messages table) ---
+	# All of these are ONE uncommitted transaction: _run_db owns the commit and retries the
+	# whole unit on a serialization error, so they must not self-commit.
+
+	def _user_id_bot_from_username(self, username):
+		# cache-free resolve returning (id, bot). Mirrors _user_id_from_username but also
+		# returns the bot flag, which the offline-message path needs to refuse bots.
+		# db collation is case-insensitive, so re-check the case in python.
+		row = self.sess().query(User.id, User.username, User.bot).filter(User.username == username).first()
+		if not row or row[1] != username:
+			return None
+		return (row[0], row[2])
+
+	def _bump_offline_tombstone(self, sender_id, recipient_id, when, count):
+		# Upsert the single (sender, recipient) tombstone: one row stands for every message
+		# from that sender that the recipient will never see, whether dropped by the cap or
+		# expired by the TTL. Keeps the newest send time so the recipient can tell roughly
+		# when they were being messaged.
+		tomb = self.sess().query(OfflineMessage).filter(OfflineMessage.recipient_user_id == recipient_id).filter(OfflineMessage.sender_user_id == sender_id).filter(OfflineMessage.msg == None).first()
+		if tomb is None:
+			self.sess().add(OfflineMessage(sender_id, recipient_id, when, None, False, count))
+			return
+		tomb.dropped_count = (tomb.dropped_count or 0) + count
+		if when > tomb.time:
+			tomb.time = when
+
+	def do_enqueue_offline_message(self, sender_id, recipient_username, msg, ex_msg):
+		# ONE unit: resolve -> refuse bots -> honour the recipient's ignore list -> enforce
+		# the per-pair cap -> insert. Returns a verdict tuple for the reactor callback.
+		resolved = self._user_id_bot_from_username(recipient_username)
+		if resolved is None:
+			return ('nouser',)
+		recipient_id, bot = resolved
+		if bot:
+			# Bots cannot receive offline messages at all: a queue of commands delivered in
+			# one burst at login would flood an autohost, which is abuse waiting to happen.
+			return ('bot',)
+		if recipient_id == sender_id:
+			return ('nouser',) # a user is never offline to themselves; nothing to queue
+		if self.is_ignored(recipient_id, sender_id):
+			# The recipient ignores the sender. Never write the row, and report success:
+			# ignore status must not be observable by probing.
+			return ('ok', recipient_id)
+		now = datetime.now()
+		n = self.sess().query(OfflineMessage).filter(OfflineMessage.recipient_user_id == recipient_id).filter(OfflineMessage.sender_user_id == sender_id).filter(OfflineMessage.msg != None).count()
+		if n >= OFFLINE_MSG_MAX_PER_PAIR:
+			# At the cap: drop the oldest content to make room, and account for it in the
+			# tombstone so the loss is reported rather than silent.
+			oldest = self.sess().query(OfflineMessage).filter(OfflineMessage.recipient_user_id == recipient_id).filter(OfflineMessage.sender_user_id == sender_id).filter(OfflineMessage.msg != None).order_by(OfflineMessage.id).first()
+			dropped_time = oldest.time
+			self.sess().delete(oldest)
+			self.sess().flush() # the delete must land before the tombstone query re-reads
+			self._bump_offline_tombstone(sender_id, recipient_id, dropped_time, 1)
+		self.sess().add(OfflineMessage(sender_id, recipient_id, now, msg, ex_msg))
+		return ('ok', recipient_id)
+
+	def do_fetch_offline_messages(self, recipient_id):
+		# Sender usernames are resolved in-query (like get_channel_messages) so the reactor
+		# callback needs no DB of its own. Ordered by id: the send order matches the order
+		# the messages were queued in.
+		res = self.sess().query(OfflineMessage.id, OfflineMessage.sender_user_id, User.username, OfflineMessage.time, OfflineMessage.msg, OfflineMessage.ex_msg, OfflineMessage.dropped_count).filter(OfflineMessage.recipient_user_id == recipient_id).join(User, User.id == OfflineMessage.sender_user_id, isouter=True).order_by(OfflineMessage.id).all()
+		return [(id, sender_id, username or "?", when, msg, ex_msg, dropped or 0)
+		        for (id, sender_id, username, when, msg, ex_msg, dropped) in res]
+
+	def do_delete_offline_messages(self, ids):
+		if not ids:
+			return 0
+		return self.sess().query(OfflineMessage).filter(OfflineMessage.id.in_(ids)).delete(synchronize_session=False)
 
 	def add_channel_message(self, channel_id, user_id, bridged_id, msg, ex_msg, date=None):
 		if date is None:

--- a/SQLUsers.py
+++ b/SQLUsers.py
@@ -1027,8 +1027,37 @@ class UsersHandler:
 		logging.info("deleting %i channel history messages", response.count())
 		response.delete(synchronize_session=False)
 
+		self.expire_offline_messages(now)
+
 		self.sess().commit()
 		self.flush_user_cache()
+
+	def expire_offline_messages(self, now=None):
+		# Drop offline message CONTENT past the TTL, but leave one tombstone per
+		# (sender, recipient) pair behind so a user returning after a long absence still
+		# learns someone tried to reach them. Tombstones themselves never expire here -
+		# they live until delivered, which is the whole point of them.
+		#
+		# Callers: clean(), which commits. Kept commit-free so it stays one unit with it.
+		if now is None:
+			now = datetime.now()
+		cutoff = now - timedelta(days=OFFLINE_MSG_TTL_DAYS)
+		expired = self.sess().query(OfflineMessage).filter(OfflineMessage.time < cutoff).filter(OfflineMessage.msg != None).all()
+		if not expired:
+			return 0
+		logging.info("expiring %i offline messages into tombstones", len(expired))
+		# Collapse per pair first: N expiring messages from one sender must become ONE
+		# tombstone counting N, not N tombstones.
+		per_pair = {}
+		for m in expired:
+			key = (m.sender_user_id, m.recipient_user_id)
+			count, newest = per_pair.get(key, (0, m.time))
+			per_pair[key] = (count + 1, max(newest, m.time))
+			self.sess().delete(m)
+		self.sess().flush() # the deletes must land before _bump_offline_tombstone re-reads
+		for (sender_id, recipient_id), (count, newest) in per_pair.items():
+			self._bump_offline_tombstone(sender_id, recipient_id, newest, count)
+		return len(expired)
 
 	def audit_access(self):
 		now = datetime.now()

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -192,10 +192,12 @@ flag_map = {
 	'u':  'say2',            # SAYFROM, Battle<->Channel unification
 	'sp': 'scriptPassword',  # scriptPassword in JOINEDBATTLE
 	'b':  'battleAuth',      # JOINBATTLEACCEPT/JOINBATTLEDENIED (typically only sent by autohosts)
+	'jsonchat': 'jsonChat',  # microsecond timestamps in JSON chat frames, JSON SAIDPRIVATE
 }
 # optional flags
 optional_flags = (
 	'b', # only useful to autohosts -> permanently optional
+	'jsonchat', # progressive enhancement: without it chat still works, just without timestamps
 )
 
 # flags for functionality that is now either compulsory or was removed
@@ -1651,6 +1653,10 @@ class Protocol:
 	# GETCHANNELMESSAGES catch-up matches what live users saw.
 	_channel_store_max = 10000 # per-channel backlog cap; only reached if the DB stalls badly
 
+	# GETCHANNELMESSAGES read cap: the newest N messages after the client's cursor. Without
+	# this a client passing last_msg_id=0 on a busy channel pulls the whole 14 day window.
+	_channel_history_max_fetch = 200
+
 	def _enqueue_channel_store(self, channel, user_id, bridged_id, msg, ex_msg):
 		# reactor thread only. Append the store and kick the pump if idle.
 		if len(channel.history_queue) >= self._channel_store_max:
@@ -2555,25 +2561,32 @@ class Protocol:
 			self.out_FAILED(client, "GETCHANNELMESSAGES", "Can't get channel messages when not joined", True)
 			return
 		try:
-			datetime.datetime.fromtimestamp(int(last_msg_id))
-		except:
+			last_msg_id = int(last_msg_id)
+			if last_msg_id < 0:
+				raise ValueError
+		except ValueError:
 			self.out_FAILED(client, "GETCHANNELMESSAGES", "Invalid id", True)
 			return
 		# 3.1: read channel history off the reactor thread. The worker returns plain
 		# [(datetime, username, msg, ex_msg, id), ...] - usernames are resolved inside the
 		# query (joins to User/BridgedUser), so the callback does NO reactor-side DB and
 		# needs no session bracket; it just formats + sends. A pure read, so no new races.
-		d = self._root.defer_db(self.userdb.get_channel_messages, client.user_id, channel.id, last_msg_id)
+		d = self._root.defer_db(self.userdb.get_channel_messages, client.user_id, channel.id, last_msg_id, self._channel_history_max_fetch)
 		d.addCallback(self._channelmessages_send, client, chan)
 		d.addErrback(self._channelmessages_failed, client)
 
-	def _channelmessages_send(self, msgs, client, chan):
+	def _channelmessages_send(self, result, client, chan):
 		# reactor-thread callback: pure send, no DB -> no commit/rollback/close bracket.
 		if client.session_id not in self._root.clients:
 			return # client disconnected during the DB call
+		msgs, truncated = result
+		rich = 'jsonchat' in client.compat
+		if truncated and rich:
+			# older messages were elided by the read cap. Only jsonchat clients can be told:
+			# the legacy dialect has no field for it, so they silently get the newest N.
+			self.out_JSON(client, 'CHANNELMESSAGESTRUNCATED', {"chanName": chan, "oldestId": msgs[0][4]})
 		for msg in msgs:
-			timestamp = int(time.mktime(msg[0].timetuple()))
-			self.out_JSON(client,  'SAID', {"chanName": chan, "time": str(timestamp), "userName": msg[1], "msg": msg[2], "ex_msg":msg[3], "id": msg[4]})
+			self.out_JSON(client, 'SAID', {"chanName": chan, "time": self._chat_timestamp(msg[0], rich), "userName": msg[1], "msg": msg[2], "ex_msg": msg[3], "id": msg[4]})
 
 	def _channelmessages_failed(self, failure, client):
 		# reactor-thread errback: a DB error fetching history. Log it loudly; unlike the
@@ -3877,6 +3890,15 @@ class Protocol:
 
 	def out_JSON(self, client, cmd, dict):
 		client.Send('JSON ' + json.dumps({cmd: dict}, separators=(',', ':')))
+
+	def _chat_timestamp(self, dt, rich):
+		# Dual-dialect timestamp for JSON chat frames. jsonchat clients get an integer of
+		# unix microseconds (tachyon's unixTime convention); clients without the flag keep
+		# the original string-of-unix-seconds, because handing an existing JSON SAID parser
+		# a value a million times too large fails silently rather than loudly.
+		if rich:
+			return int(dt.timestamp()) * 1000000 + dt.microsecond
+		return str(int(time.mktime(dt.timetuple())))
 
 def check_protocol_commands():
 	for command in restricted_list:

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -192,7 +192,7 @@ flag_map = {
 	'u':  'say2',            # SAYFROM, Battle<->Channel unification
 	'sp': 'scriptPassword',  # scriptPassword in JOINEDBATTLE
 	'b':  'battleAuth',      # JOINBATTLEACCEPT/JOINBATTLEDENIED (typically only sent by autohosts)
-	'jsonchat': 'jsonChat',  # microsecond timestamps in JSON chat frames, JSON SAIDPRIVATE
+	'jsonchat': 'jsonChat',  # microsecond timestamps in JSON chat frames
 }
 # optional flags
 optional_flags = (

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -192,7 +192,7 @@ flag_map = {
 	'u':  'say2',            # SAYFROM, Battle<->Channel unification
 	'sp': 'scriptPassword',  # scriptPassword in JOINEDBATTLE
 	'b':  'battleAuth',      # JOINBATTLEACCEPT/JOINBATTLEDENIED (typically only sent by autohosts)
-	'jsonchat': 'jsonChat',  # microsecond timestamps in JSON chat frames
+	'jsonchat': 'jsonChat',  # microsecond timestamps in JSON chat frames, JSON SAIDPRIVATE
 }
 # optional flags
 optional_flags = (

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -1249,6 +1249,71 @@ class Protocol:
 		if not client.bot and 'mod' in client.accesslevels:
 			self.in_JOIN(client, "moderator")
 
+		self._deliver_offline_messages(client)
+
+	def _deliver_offline_messages(self, client):
+		# reactor thread, at the end of login: client.ignored is populated and LOGININFOEND
+		# has been sent, so the deferred reply lands after the client is fully initialised.
+		# Bots never have queued messages (the enqueue path refuses them), so don't ask.
+		if client.bot:
+			return
+		d = self._root.defer_db(self.userdb.do_fetch_offline_messages, client.user_id)
+		d.addCallback(self._offline_messages_send, client)
+		d.addErrback(self._offline_messages_failed, client)
+
+	def _offline_messages_send(self, msgs, client):
+		# reactor-thread callback: sends, then defers the delete. No reactor-side DB of its
+		# own, so no session bracket.
+		#
+		# Delivery is AT-MOST-ONCE: Send is buffered and unacknowledged, so a disconnect
+		# between the send and the delete landing loses the messages. Closing that would
+		# need a client ack command; deleting only while the client is still connected
+		# narrows the window but does not shut it.
+		if client.session_id not in self._root.clients:
+			return # client disconnected during the DB call; leave the rows for next login
+		if not msgs:
+			return
+		rich = 'jsonchat' in client.compat
+		delivered = []
+		for (id, sender_id, sender_name, when, msg, ex_msg, dropped_count) in msgs:
+			# Re-check the ignore list in memory: enqueue already filtered against it, but the
+			# recipient may have ignored the sender while the message sat in the queue.
+			if sender_id in client.ignored:
+				delivered.append(id) # drop it, but still clear the row
+				continue
+			if msg is None:
+				self._send_offline_tombstone(client, sender_name, when, dropped_count, rich)
+			elif rich:
+				cmd = 'SAIDPRIVATEEX' if ex_msg else 'SAIDPRIVATE'
+				self.out_JSON(client, cmd, {"userName": sender_name, "msg": msg, "ex_msg": bool(ex_msg), "time": self._chat_timestamp(when, True)})
+			else:
+				# Legacy dialect: the message arrives as if it were just sent. There is
+				# nowhere in SAIDPRIVATE to put the original time, which is precisely what
+				# jsonchat exists to fix.
+				cmd = 'SAIDPRIVATEEX' if ex_msg else 'SAIDPRIVATE'
+				client.Send('%s %s %s' % (cmd, sender_name, msg))
+			delivered.append(id)
+		logging.info('[%s] <%s> delivered %d queued offline message(s)' % (client.session_id, client.username, len(delivered)))
+		d = self._root.defer_db(self.userdb.do_delete_offline_messages, delivered)
+		d.addErrback(self._offline_delete_failed, client)
+
+	def _send_offline_tombstone(self, client, sender_name, when, dropped_count, rich):
+		# The content is gone (expired or dropped by the per-sender cap) but the recipient is
+		# still told someone tried to reach them, so they can ask rather than never knowing.
+		if rich:
+			self.out_JSON(client, 'OFFLINEMESSAGESDROPPED', {"userName": sender_name, "count": dropped_count, "time": self._chat_timestamp(when, True)})
+			return
+		self.out_SERVERMSG(client, "%s sent you %d message(s) while you were away, but they expired before you returned. Ask them to resend." % (sender_name, dropped_count))
+
+	def _offline_messages_failed(self, failure, client):
+		# reactor-thread errback: nothing was delivered and nothing was deleted, so the
+		# messages simply wait for the next login. Log it; don't spam the user on every login.
+		logging.error("offline message fetch DB error for <%s>: %s" % (getattr(client, 'username', '?'), failure.getTraceback()))
+
+	def _offline_delete_failed(self, failure, client):
+		# The messages were sent but the delete failed, so they will be delivered again on
+		# the next login. Duplicates are the safe direction here, but say so loudly.
+		logging.error("offline message delete failed for <%s> (they will be redelivered): %s" % (getattr(client, 'username', '?'), failure.getTraceback()))
 
 	def in_CONFIRMAGREEMENT(self, client, verification_code = ""):
 		# Confirm the terms of service as shown with the AGREEMENT commands. (Users must accept the terms of service to use their account.)
@@ -1452,7 +1517,7 @@ class Protocol:
 
 		receiver = self.clientFromUsername(user)
 		if not receiver:
-			logging.info('[%s] <%s>: user to pm is not online: %s' % (client.session_id, client.username, user))
+			self._enqueue_offline_message(client, user, msg, False)
 			return
 		client.Send('SAYPRIVATE %s %s' % (user, msg))
 		if not self.is_ignored(receiver, client):
@@ -1469,10 +1534,53 @@ class Protocol:
 			return
 
 		receiver = self.clientFromUsername(user)
-		if receiver:
-			client.Send('SAYPRIVATEEX %s %s' % (user, msg))
-			if not self.is_ignored(receiver, client):
-				receiver.Send('SAIDPRIVATEEX %s %s' % (client.username, msg))
+		if not receiver:
+			self._enqueue_offline_message(client, user, msg, True)
+			return
+		client.Send('SAYPRIVATEEX %s %s' % (user, msg))
+		if not self.is_ignored(receiver, client):
+			receiver.Send('SAIDPRIVATEEX %s %s' % (client.username, msg))
+
+	# --- offline direct messages ---
+	# The target is not online (clientFromUsername without fromdb only sees live clients),
+	# so queue the message for their next login instead of dropping it. Everything that can
+	# refuse the send needs the db, so it all happens in one worker; the reactor callback
+	# only echoes back to the sender.
+
+	def _enqueue_offline_message(self, client, user, msg, ex_msg):
+		# reactor thread. Hand off to the worker; the echo happens in the callback so we
+		# never echo a message that was refused (unknown user, bot target).
+		cmd = 'SAYPRIVATEEX' if ex_msg else 'SAYPRIVATE'
+		d = self._root.defer_db(self.userdb.do_enqueue_offline_message, client.user_id, user, msg, ex_msg)
+		d.addCallback(self._offline_message_queued, client, user, msg, cmd)
+		d.addErrback(self._offline_message_failed, client, user, cmd)
+
+	def _offline_message_queued(self, result, client, user, msg, cmd):
+		# reactor-thread callback: pure send, no DB -> no commit/rollback/close bracket.
+		if client.session_id not in self._root.clients:
+			return # sender disconnected during the DB call
+		verdict = result[0]
+		if verdict == 'ok':
+			# Echo exactly as the online path does, and say nothing about the queueing: the
+			# sender is not told whether the message was delivered now or stored for later.
+			# An ignored sender also lands here, so ignore status stays unobservable.
+			client.Send('%s %s %s' % (cmd, user, msg))
+			return
+		if verdict == 'bot':
+			# An explicit refusal deserves an explicit reason, and bot status is already
+			# public via ADDUSER, so there is nothing leaked by saying so.
+			self.out_FAILED(client, cmd, "Cannot send offline messages to bots (%s)" % user, False)
+			return
+		# 'nouser': unchanged from the previous behaviour - log it, tell the sender nothing.
+		logging.info('[%s] <%s>: user to pm is not online: %s' % (client.session_id, client.username, user))
+
+	def _offline_message_failed(self, failure, client, user, cmd):
+		# reactor-thread errback: the write did not happen, so mutate nothing. Do NOT echo -
+		# an echo here would tell the sender their message is queued when it was lost.
+		logging.error("%s offline queue DB error for <%s> -> %s: %s" % (cmd, getattr(client, 'username', '?'), user, failure.getTraceback()))
+		if client.session_id not in self._root.clients:
+			return
+		self.out_FAILED(client, cmd, "Server error queueing your message for %s, it was not sent" % user, False)
 
 	def in_BATTLEHOSTMSG(self, client, battle_name, username, msg):
 		# battle host sends a 'servermsg' style message, within a battle to a single user

--- a/tests/integration/channelmsgtest.py
+++ b/tests/integration/channelmsgtest.py
@@ -46,12 +46,13 @@ class Sock:
                 self.buf += chunk.decode(errors="replace")
         except socket.timeout:
             pass
-    def collect_said(self, chan, want, timeout=4.0):
-        # GETCHANNELMESSAGES has no end marker; collect `want` SAID lines for `chan`
-        # or give up after `timeout`. Returns list of (id, userName, msg, ex_msg) in
-        # arrival order.
+    def collect_said_raw(self, chan, want, timeout=8.0):
+        # GETCHANNELMESSAGES has no end marker; collect `want` SAID frames for `chan` or
+        # give up after `timeout`. Returns (said_dicts, other_frames) where other_frames
+        # holds any non-SAID JSON frames seen along the way (e.g. the truncation notice).
         deadline = time.time() + timeout
         got = []
+        others = []
         while len(got) < want and time.time() < deadline:
             self.s.settimeout(max(0.05, deadline - time.time()))
             try:
@@ -72,10 +73,18 @@ class Sock:
                 except Exception:
                     continue
                 said = obj.get("SAID")
-                if not said or said.get("chanName") != chan:
+                if said is None:
+                    others.append(obj)
                     continue
-                got.append((int(said["id"]), said["userName"], said["msg"], said["ex_msg"]))
-        return got
+                if said.get("chanName") != chan:
+                    continue
+                got.append(said)
+        return got, others
+
+    def collect_said(self, chan, want, timeout=4.0):
+        # arrival-order (id, userName, msg, ex_msg) tuples
+        said, _ = self.collect_said_raw(chan, want, timeout)
+        return [(int(m["id"]), m["userName"], m["msg"], m["ex_msg"]) for m in said]
     def close(self):
         try: self.s.close()
         except: pass
@@ -97,9 +106,13 @@ def register_and_confirm(user):
     s.close()
     return ok
 
-def login_keep(user):
+def login_keep(user, compat=None):
+    # compat flags ride in the login sentence: "<agent>\t<last_id>\t<flags>"
     s = connect()
-    s.sendall(("LOGIN %s %s 0 * TestClient\n" % (user, PW)).encode())
+    if compat:
+        s.sendall(("LOGIN %s %s 0 * TestClient\t0\t%s\n" % (user, PW, compat)).encode())
+    else:
+        s.sendall(("LOGIN %s %s 0 * TestClient\n" % (user, PW)).encode())
     resp = recv_until(s, "LOGININFOEND", timeout=8)
     if "ACCEPTED" not in resp or "LOGININFOEND" not in resp:
         s.close()
@@ -199,6 +212,108 @@ if sk is not None:
     else:
         print("WARN: invalid last_msg_id did not yield expected FAILED (buf tail: %r)" % sk.buf[-200:])
     sk.close()
+
+# ---------- read cap: newest-N, truncation signal, timestamp dialects ----------
+# Seeded AFTER the checks above so their exact-count assertions are unaffected.
+CAP = 200
+EXTRA = 205  # push the channel past the cap
+conn = pymysql.connect(**DB)
+cur = conn.cursor()
+seed_time = "2030-01-01 00:00:00"  # distinctive + stable: lets us pin the exact timestamp
+rows = [(chan_id, A[0], None, seed_time, "cap%d" % i, 0) for i in range(EXTRA)]
+cur.executemany(
+    "INSERT INTO channel_history (channel_id, user_id, bridged_id, time, msg, ex_msg) VALUES (%s,%s,%s,%s,%s,%s)",
+    rows)
+conn.close()
+print("seeded %d extra rows to exceed the %d cap" % (EXTRA, CAP))
+
+# expected microsecond value for seed_time, computed the same way the server does
+# (naive datetime -> local epoch), so this pins the dialect without hardcoding a TZ.
+import datetime as _dt
+_seed_dt = _dt.datetime(2030, 1, 1, 0, 0, 0)
+EXPECT_US = int(_seed_dt.timestamp()) * 1000000
+EXPECT_SEC = str(int(time.mktime(_seed_dt.timetuple())))
+
+def check_cap(user, compat, label):
+    sk = login_keep(user, compat)
+    if sk is None:
+        errors.append("%s: login failed" % label); return None
+    try:
+        sk.send("JOIN %s" % CHAN)
+        sk.drain(0.6)
+        sk.send("GETCHANNELMESSAGES %s 0" % CHAN)
+        said, others = sk.collect_said_raw(CHAN, CAP)
+        if len(said) != CAP:
+            errors.append("%s: got %d SAID, want exactly %d (cap)" % (label, len(said), CAP))
+            return None
+        # newest-N, not oldest-N: the last seeded row must be present, the first must not
+        msgs = [m["msg"] for m in said]
+        if msgs[-1] != "cap%d" % (EXTRA - 1):
+            errors.append("%s: newest message is %r, want %r" % (label, msgs[-1], "cap%d" % (EXTRA - 1)))
+        if "m0" in msgs:
+            errors.append("%s: oldest message m0 present - returned oldest-N not newest-N" % label)
+        ids = [int(m["id"]) for m in said]
+        if ids != sorted(ids):
+            errors.append("%s: ids not ascending" % label)
+        return said, others
+    finally:
+        sk.close()
+
+def report(label, before):
+    # print PASS only if this section actually added no errors, else print what broke
+    new = errors[before:]
+    if new:
+        print("FAIL: %s" % label)
+        for e in new:
+            print("  ", e)
+    else:
+        print("PASS: %s" % label)
+
+# legacy client: string-of-seconds, and no truncation frame (it has no field for one)
+n = len(errors)
+r = check_cap(viewers[1], None, "legacy")
+if r:
+    said, others = r
+    t = said[-1]["time"]
+    if not (isinstance(t, str) and t == EXPECT_SEC):
+        errors.append("legacy: time=%r (%s), want str %r" % (t, type(t).__name__, EXPECT_SEC))
+    if any("CHANNELMESSAGESTRUNCATED" in o for o in others):
+        errors.append("legacy: got a truncation frame it cannot parse")
+report("legacy dialect -> string seconds, no truncation frame", n)
+
+# jsonchat client: integer microseconds + an explicit truncation notice
+n = len(errors)
+r = check_cap(viewers[2], "jsonchat", "jsonchat")
+if r:
+    said, others = r
+    t = said[-1]["time"]
+    if not (isinstance(t, int) and t == EXPECT_US):
+        errors.append("jsonchat: time=%r (%s), want int %r" % (t, type(t).__name__, EXPECT_US))
+    trunc = [o["CHANNELMESSAGESTRUNCATED"] for o in others if "CHANNELMESSAGESTRUNCATED" in o]
+    if not trunc:
+        errors.append("jsonchat: no truncation frame despite %d rows > %d cap" % (EXTRA, CAP))
+    elif trunc[0].get("oldestId") != int(said[0]["id"]):
+        errors.append("jsonchat: truncation oldestId=%r, want %r" % (trunc[0].get("oldestId"), said[0]["id"]))
+report("jsonchat dialect -> int microseconds + truncation notice", n)
+
+# a cursor near the head must NOT report truncation (the cap only bites on a cold start)
+n = len(errors)
+sk = login_keep(viewers[3], "jsonchat")
+if sk is not None:
+    sk.send("JOIN %s" % CHAN)
+    sk.drain(0.6)
+    conn = pymysql.connect(**DB); cur = conn.cursor()
+    cur.execute("SELECT MAX(id) FROM channel_history WHERE channel_id=%s", (chan_id,))
+    max_id = cur.fetchone()[0]
+    conn.close()
+    sk.send("GETCHANNELMESSAGES %s %d" % (CHAN, max_id - 3))
+    said, others = sk.collect_said_raw(CHAN, 3, timeout=3.0)
+    if len(said) != 3:
+        errors.append("resume: got %d SAID, want 3" % len(said))
+    elif any("CHANNELMESSAGESTRUNCATED" in o for o in others):
+        errors.append("resume: truncation reported for a 3-message catch-up under the cap")
+    sk.close()
+report("short resume returns 3 messages, no truncation", n)
 
 # ---------- disconnect-during-call check ----------
 dropped = 0

--- a/tests/integration/offlinemsgtest.py
+++ b/tests/integration/offlinemsgtest.py
@@ -1,0 +1,331 @@
+"""
+e2e for offline direct messages: queue a PM to a logged-out user, then assert it is
+delivered on their next login, in the right dialect, and deleted afterwards.
+
+Covers: sender echo + row written, legacy delivery (plain SAIDPRIVATE, no timestamp),
+jsonchat delivery (JSON SAIDPRIVATE carrying the ORIGINAL send time in microseconds),
+delete-on-delivery, the per-pair cap collapsing into one tombstone, bots refused with
+nothing stored, and an ignored sender seeing success with nothing stored.
+
+Run: source venv/bin/activate; python3 tests/integration/offlinemsgtest.py
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import DB_KWARGS, HOST, PORT
+import socket, hashlib, base64, time, sys, json, datetime
+import pymysql
+
+TAG = sys.argv[1] if len(sys.argv) > 1 else "o1"
+raw_pw = "secretpw"
+PW = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+
+A = "om_%s_sender" % TAG     # sender, stays online
+B = "om_%s_legacy" % TAG     # recipient on an old lobby
+C = "om_%s_rich" % TAG       # recipient advertising jsonchat
+BOT = "om_%s_bot" % TAG      # bot recipient: must refuse
+IG = "om_%s_ignorer" % TAG   # ignores A
+CAPU = "om_%s_cap" % TAG     # cap victim
+ALL = [A, B, C, BOT, IG, CAPU]
+
+DB = DB_KWARGS
+errors = []
+
+def check(cond, label):
+    if not cond:
+        errors.append(label)
+
+def report(label, before):
+    new = errors[before:]
+    if new:
+        print("FAIL: %s" % label)
+        for e in new:
+            print("  ", e)
+    else:
+        print("PASS: %s" % label)
+
+# ---------- socket helpers ----------
+def recv_until(s, substr, timeout=8):
+    s.settimeout(timeout)
+    buf = b""
+    try:
+        while substr.encode() not in buf:
+            chunk = s.recv(8192)
+            if not chunk:
+                break
+            buf += chunk
+    except socket.timeout:
+        pass
+    return buf.decode(errors="replace")
+
+class Sock:
+    def __init__(self, s, preamble=""):
+        self.s = s
+        self.buf = preamble
+    def send(self, line):
+        self.s.sendall((line + "\n").encode())
+    def drain(self, seconds=1.0):
+        self.s.settimeout(seconds)
+        try:
+            while True:
+                chunk = self.s.recv(8192)
+                if not chunk:
+                    break
+                self.buf += chunk.decode(errors="replace")
+        except socket.timeout:
+            pass
+        return self.buf
+    def json_frames(self):
+        out = []
+        for ln in self.buf.split("\n"):
+            ln = ln.strip()
+            if not ln.startswith("JSON "):
+                continue
+            try:
+                out.append(json.loads(ln[5:]))
+            except Exception:
+                pass
+        return out
+    def lines(self, prefix):
+        return [ln.strip() for ln in self.buf.split("\n") if ln.strip().startswith(prefix)]
+    def close(self):
+        try: self.s.close()
+        except Exception: pass
+
+def connect():
+    s = socket.create_connection((HOST, PORT))
+    recv_until(s, "\n")
+    return s
+
+def register_and_confirm(user):
+    s = connect()
+    s.sendall(("REGISTER %s %s\n" % (user, PW)).encode())
+    recv_until(s, "\n")
+    time.sleep(2.5)
+    s.sendall(("LOGIN %s %s 0 * TestClient\n" % (user, PW)).encode())
+    recv_until(s, "AGREEMENTEND")
+    s.sendall(b"CONFIRMAGREEMENT\n")
+    ok = "LOGININFOEND" in recv_until(s, "LOGININFOEND")
+    s.close()
+    return ok
+
+def login_keep(user, compat=None):
+    s = connect()
+    if compat:
+        s.sendall(("LOGIN %s %s 0 * TestClient\t0\t%s\n" % (user, PW, compat)).encode())
+    else:
+        s.sendall(("LOGIN %s %s 0 * TestClient\n" % (user, PW)).encode())
+    resp = recv_until(s, "LOGININFOEND", timeout=8)
+    if "ACCEPTED" not in resp or "LOGININFOEND" not in resp:
+        s.close()
+        return None
+    # keep whatever arrived with LOGININFOEND: delivery races the login reply
+    return Sock(s, preamble=resp)
+
+# ---------- db helpers ----------
+def q(sql, args=()):
+    conn = pymysql.connect(**DB)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql, args)
+        return cur.fetchall()
+    finally:
+        conn.close()
+
+def x(sql, args=()):
+    conn = pymysql.connect(**DB)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql, args)
+        conn.commit()
+    finally:
+        conn.close()
+
+def uid(name):
+    r = q("SELECT id FROM users WHERE username=%s", (name,))
+    return r[0][0] if r else None
+
+def msg_rows(sender, recipient):
+    return q("""SELECT o.id, o.msg, o.ex_msg, o.dropped_count, o.time FROM offline_messages o
+                WHERE o.sender_user_id=%s AND o.recipient_user_id=%s ORDER BY o.id""",
+             (uid(sender), uid(recipient)))
+
+# ---------- setup ----------
+for u in ALL:
+    if not register_and_confirm(u):
+        print("ABORT: could not register %s" % u); sys.exit(1)
+print("setup confirmed: %d/%d" % (len(ALL), len(ALL)))
+
+x("UPDATE users SET bot=1 WHERE username=%s", (BOT,))
+x("DELETE FROM offline_messages")
+# IG ignores A (via the db: IGNORE needs both online, and we want A's target offline)
+x("DELETE FROM ignores WHERE user_id=%s", (uid(IG),))
+x("INSERT INTO ignores (user_id, ignored_user_id, reason, time) VALUES (%s,%s,%s,NOW())",
+  (uid(IG), uid(A), "test"))
+
+sender = login_keep(A)
+if sender is None:
+    print("ABORT: sender could not log in"); sys.exit(1)
+
+# ---------- 1. queue to an offline user: echo + row written ----------
+n = len(errors)
+sender.send("SAYPRIVATE %s hello while away" % B)
+sender.drain(1.5)
+echo = [ln for ln in sender.lines("SAYPRIVATE") if B in ln]
+check(bool(echo), "sender should get a SAYPRIVATE echo for an offline target, buf=%r" % sender.buf[-200:])
+r = msg_rows(A, B)
+check(len(r) == 1, "one row should be queued, got %d" % len(r))
+check(r and r[0][1] == "hello while away", "stored msg wrong: %r" % (r and r[0][1],))
+report("queue to offline user -> echo + row stored", n)
+
+# ---------- 2. bot recipient: FAILED, nothing stored ----------
+n = len(errors)
+sender.buf = ""
+sender.send("SAYPRIVATE %s !host smallmap" % BOT)
+sender.drain(1.5)
+check("FAILED" in sender.buf and "bots" in sender.buf,
+      "PM to an offline bot should be FAILED, buf=%r" % sender.buf[-200:])
+check(len(msg_rows(A, BOT)) == 0, "a message to a bot must not be stored")
+report("offline bot refused, nothing stored", n)
+
+# ---------- 3. ignored sender: echo (indistinguishable), nothing stored ----------
+n = len(errors)
+sender.buf = ""
+sender.send("SAYPRIVATE %s you cannot see this" % IG)
+sender.drain(1.5)
+check(bool([ln for ln in sender.lines("SAYPRIVATE") if IG in ln]),
+      "an ignored sender must still get an echo, buf=%r" % sender.buf[-200:])
+check("FAILED" not in sender.buf, "an ignored sender must not be able to detect the ignore")
+check(len(msg_rows(A, IG)) == 0, "an ignored sender's message must never be stored")
+report("ignored sender -> echo, nothing stored", n)
+
+# ---------- 4. legacy delivery: plain SAIDPRIVATE, then deleted ----------
+n = len(errors)
+b = login_keep(B)
+if b is None:
+    errors.append("legacy recipient could not log in")
+else:
+    b.drain(2.0)
+    said = [ln for ln in b.lines("SAIDPRIVATE") if A in ln and "hello while away" in ln]
+    check(bool(said), "legacy client should receive plain SAIDPRIVATE, buf=%r" % b.buf[-300:])
+    check(not any("SAIDPRIVATE" in json.dumps(f) for f in b.json_frames()),
+          "legacy client must not receive JSON frames")
+    time.sleep(1.0)  # let the delete deferred land
+    check(len(msg_rows(A, B)) == 0, "delivered message must be deleted (delete-on-delivery)")
+    b.close()
+report("legacy delivery -> plain SAIDPRIVATE + delete-on-delivery", n)
+
+# ---------- 5. jsonchat delivery: original timestamp preserved ----------
+n = len(errors)
+# backdate the row so "original send time" is unmistakably not "login time"
+sent_at = datetime.datetime.now().replace(microsecond=0) - datetime.timedelta(hours=9)
+x("DELETE FROM offline_messages")
+x("""INSERT INTO offline_messages (sender_user_id, recipient_user_id, time, msg, ex_msg, dropped_count)
+     VALUES (%s,%s,%s,%s,0,0)""", (uid(A), uid(C), sent_at, "sent nine hours ago"))
+expect_us = int(sent_at.timestamp()) * 1000000
+
+c = login_keep(C, "jsonchat")
+if c is None:
+    errors.append("jsonchat recipient could not log in")
+else:
+    c.drain(2.0)
+    frames = [f["SAIDPRIVATE"] for f in c.json_frames() if "SAIDPRIVATE" in f]
+    check(len(frames) == 1, "jsonchat client should get exactly one JSON SAIDPRIVATE, got %d (buf=%r)"
+          % (len(frames), c.buf[-300:]))
+    if frames:
+        f = frames[0]
+        check(f.get("userName") == A, "frame userName=%r, want %r" % (f.get("userName"), A))
+        check(f.get("msg") == "sent nine hours ago", "frame msg=%r" % (f.get("msg"),))
+        t = f.get("time")
+        check(isinstance(t, int), "frame time should be an int, got %r (%s)" % (t, type(t).__name__))
+        check(t == expect_us, "frame time=%r, want the ORIGINAL send time %r (not login time)" % (t, expect_us))
+    # no plain SAIDPRIVATE for a jsonchat client - it would double up
+    check(not [ln for ln in c.lines("SAIDPRIVATE") if not ln.startswith("JSON")],
+          "jsonchat client must not also get a plain SAIDPRIVATE")
+    time.sleep(1.0)
+    check(len(msg_rows(A, C)) == 0, "delivered message must be deleted")
+    c.close()
+report("jsonchat delivery -> JSON SAIDPRIVATE with the original timestamp", n)
+
+# ---------- 6. per-pair cap collapses into one tombstone ----------
+n = len(errors)
+x("DELETE FROM offline_messages")
+CAP = 50
+sender.buf = ""
+for i in range(CAP + 1):
+    sender.send("SAYPRIVATE %s capmsg%d" % (CAPU, i))
+    time.sleep(0.02)  # stay under the byte-rate flood limit
+deadline = time.time() + 15
+while time.time() < deadline:
+    r = msg_rows(A, CAPU)
+    if len(r) == CAP + 1:  # CAP content + 1 tombstone
+        break
+    time.sleep(0.3)
+r = msg_rows(A, CAPU)
+content = [row for row in r if row[1] is not None]
+tombs = [row for row in r if row[1] is None]
+check(len(content) == CAP, "content should be capped at %d, got %d" % (CAP, len(content)))
+check(len(tombs) == 1, "exceeding the cap should leave exactly one tombstone, got %d" % len(tombs))
+check(tombs and tombs[0][3] == 1, "tombstone dropped_count should be 1, got %r" % (tombs and tombs[0][3],))
+check(content and content[0][1] == "capmsg1", "oldest should have been dropped, first is %r" % (content and content[0][1],))
+report("51st message to one user collapses the oldest into a tombstone", n)
+
+# ---------- 7. tombstone is delivered, in both dialects ----------
+n = len(errors)
+x("DELETE FROM offline_messages")
+x("""INSERT INTO offline_messages (sender_user_id, recipient_user_id, time, msg, ex_msg, dropped_count)
+     VALUES (%s,%s,NOW(),NULL,0,7)""", (uid(A), uid(CAPU)))
+cu = login_keep(CAPU)
+if cu is None:
+    errors.append("cap user could not log in (legacy tombstone)")
+else:
+    cu.drain(2.0)
+    check("SERVERMSG" in cu.buf and "expired" in cu.buf,
+          "legacy client should get a plain-text tombstone notice, buf=%r" % cu.buf[-300:])
+    cu.close()
+    time.sleep(1.0)
+    check(len(msg_rows(A, CAPU)) == 0, "a delivered tombstone must be deleted")
+report("legacy tombstone -> SERVERMSG notice + deleted", n)
+
+n = len(errors)
+x("""INSERT INTO offline_messages (sender_user_id, recipient_user_id, time, msg, ex_msg, dropped_count)
+     VALUES (%s,%s,NOW(),NULL,0,7)""", (uid(A), uid(CAPU)))
+cu = login_keep(CAPU, "jsonchat")
+if cu is None:
+    errors.append("cap user could not log in (jsonchat tombstone)")
+else:
+    cu.drain(2.0)
+    drops = [f["OFFLINEMESSAGESDROPPED"] for f in cu.json_frames() if "OFFLINEMESSAGESDROPPED" in f]
+    check(len(drops) == 1, "jsonchat client should get one tombstone frame, got %d (buf=%r)" % (len(drops), cu.buf[-300:]))
+    if drops:
+        check(drops[0].get("count") == 7, "tombstone count=%r, want 7" % (drops[0].get("count"),))
+        check(drops[0].get("userName") == A, "tombstone userName=%r, want %r" % (drops[0].get("userName"), A))
+    cu.close()
+report("jsonchat tombstone -> OFFLINEMESSAGESDROPPED frame", n)
+
+# ---------- 8. online path is unchanged ----------
+n = len(errors)
+x("DELETE FROM offline_messages")
+b = login_keep(B)
+if b is None:
+    errors.append("recipient could not log in for the online check")
+else:
+    b.drain(1.0); b.buf = ""
+    sender.buf = ""
+    sender.send("SAYPRIVATE %s live message" % B)
+    b.drain(1.5)
+    check(bool([ln for ln in b.lines("SAIDPRIVATE") if "live message" in ln]),
+          "an online PM must still be delivered live, buf=%r" % b.buf[-200:])
+    check(len(msg_rows(A, B)) == 0, "an online PM must not be queued")
+    b.close()
+report("online PM still delivered live and never queued", n)
+
+sender.close()
+x("DELETE FROM offline_messages")
+x("DELETE FROM ignores WHERE user_id=%s", (uid(IG),))
+
+if errors:
+    print("FAIL: %d errors total" % len(errors))
+    sys.exit(1)
+print("PASS: offline direct messages e2e")
+sys.exit(0)

--- a/tests/worker/offlinemessageworkertest.py
+++ b/tests/worker/offlinemessageworkertest.py
@@ -180,10 +180,62 @@ check(fetched and fetched[0][6] == 7, "tombstone dropped_count should survive th
 run_worker(udb.do_delete_offline_messages, [fetched[0][0]])
 check(run_worker(udb.do_fetch_offline_messages, rid) == [], "a delivered tombstone must be deleted")
 
+# ---------- TTL: content expires into ONE tombstone per pair, tombstones do not ----------
+wipe_msgs()
+TTL = SQLUsers.OFFLINE_MSG_TTL_DAYS
+# microsecond=0: the DATETIME columns store whole seconds, so a value with microseconds
+# would not survive the round trip and the comparisons below would be comparing a python
+# datetime against a truncated one.
+old = (datetime.now() - timedelta(days=TTL + 1)).replace(microsecond=0)
+recent = (datetime.now() - timedelta(days=TTL - 1)).replace(microsecond=0)
+s = sm.sess()
+for i in range(3):
+    s.add(SQLUsers.OfflineMessage(sid, rid, old + timedelta(seconds=i), "old%d" % i, False))
+s.add(SQLUsers.OfflineMessage(sid, rid, recent, "still fresh", False))
+s.add(SQLUsers.OfflineMessage(oid, rid, old, "other sender old", False))  # a second pair
+s.commit()
+sm.close_guard()
+
+n = run_worker(udb.expire_offline_messages)
+check(n == 4, "expire should have expired 4 messages (3 + 1 from another sender), got %r" % (n,))
+
+r = rows(sid, rid)
+content = [x for x in r if x[1] is not None]
+tombs = [x for x in r if x[1] is None]
+check(len(content) == 1 and content[0][1] == "still fresh",
+      "content inside the TTL must survive, got %r" % (content,))
+check(len(tombs) == 1, "3 expiring messages from one sender must collapse to ONE tombstone, got %d" % len(tombs))
+check(tombs and tombs[0][3] == 3, "tombstone should count 3 expired, got %r" % (tombs and tombs[0][3],))
+check(tombs and tombs[0][4] == old + timedelta(seconds=2),
+      "tombstone time should be the NEWEST expired message, got %r want %r" % (tombs and tombs[0][4], old + timedelta(seconds=2)))
+
+# a separate sender gets its own tombstone
+otombs = [x for x in rows(oid, rid) if x[1] is None]
+check(len(otombs) == 1, "a different sender must get its own tombstone, got %d" % len(otombs))
+check(otombs and otombs[0][3] == 1, "other sender tombstone count should be 1, got %r" % (otombs and otombs[0][3],))
+
+# tombstones are NOT expired by a second pass, however old they are
+n2 = run_worker(udb.expire_offline_messages)
+check(n2 == 0, "a second expire pass should find nothing, got %r" % (n2,))
+check(len([x for x in rows(sid, rid) if x[1] is None]) == 1,
+      "an old tombstone must survive expiry - it lives until delivered")
+
+# an expiry after a cap-drop accumulates into the same tombstone rather than a second one
+wipe_msgs()
+s = sm.sess()
+s.add(SQLUsers.OfflineMessage(sid, rid, old, None, False, 2))  # pre-existing tombstone
+s.add(SQLUsers.OfflineMessage(sid, rid, old, "expiring", False))
+s.commit()
+sm.close_guard()
+run_worker(udb.expire_offline_messages)
+r = rows(sid, rid)
+check(len(r) == 1 and r[0][1] is None, "expiry must reuse the existing tombstone, got %r" % (r,))
+check(r and r[0][3] == 3, "tombstone should accumulate to 3 (2 dropped + 1 expired), got %r" % (r and r[0][3],))
+
 wipe_msgs()
 if errors:
     print("FAIL (%d):" % len(errors))
     for e in errors:
         print("  -", e)
     sys.exit(1)
-print("PASS: offline message workers (enqueue/cap/tombstone/ignore/bot/fetch/delete)")
+print("PASS: offline message workers (enqueue/cap/tombstone/ignore/bot/fetch/delete/expiry)")

--- a/tests/worker/offlinemessageworkertest.py
+++ b/tests/worker/offlinemessageworkertest.py
@@ -1,0 +1,189 @@
+"""
+Worker-unit tests for the offline direct message store (do_enqueue_offline_message,
+do_fetch_offline_messages, do_delete_offline_messages). Runs in-process against the
+MariaDB test db (no server needed). Mirrors _run_db.
+
+RED expectation before implementation: AttributeError (the workers don't exist).
+
+Run: source venv/bin/activate; python3 tests/worker/offlinemessageworkertest.py
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import DB_URL
+from datetime import datetime, timedelta
+import sys
+import sqlalchemy
+import SQLUsers
+
+SENDER = "phase3_om_sender"
+RECIP = "phase3_om_recip"
+BOT = "phase3_om_bot"
+OTHER = "phase3_om_other"
+ALL = [SENDER, RECIP, BOT, OTHER]
+
+class FakeRoot:
+    def __init__(self, engine):
+        self.session_manager = SQLUsers.session_manager(self, engine)
+
+engine = sqlalchemy.create_engine(DB_URL, pool_size=5, pool_recycle=3600)
+root = FakeRoot(engine)
+sm = root.session_manager
+udb = SQLUsers.UsersHandler(root)
+
+errors = []
+def check(cond, label):
+    if not cond:
+        errors.append(label)
+
+def run_worker(fn, *args):
+    # mirrors DataHandler._run_db: call the worker, commit, always close
+    try:
+        res = fn(*args)
+        sm.commit_guard()
+        return res
+    finally:
+        sm.close_guard()
+
+def mkuser(name, bot=0):
+    s = sm.sess()
+    s.query(SQLUsers.User).filter(SQLUsers.User.username == name).delete()
+    s.commit()
+    u = SQLUsers.User(name, "pw", "1.2.3.4", None, 'user')
+    u.bot = bot
+    s.add(u)
+    s.commit()
+    uid = u.id
+    sm.close_guard()
+    return uid
+
+def rows(sender_id, recipient_id):
+    s = sm.sess()
+    r = s.query(SQLUsers.OfflineMessage).filter(
+        SQLUsers.OfflineMessage.sender_user_id == sender_id).filter(
+        SQLUsers.OfflineMessage.recipient_user_id == recipient_id).order_by(
+        SQLUsers.OfflineMessage.id).all()
+    out = [(x.id, x.msg, x.ex_msg, x.dropped_count, x.time) for x in r]
+    sm.close_guard()
+    return out
+
+def wipe_msgs():
+    s = sm.sess()
+    s.query(SQLUsers.OfflineMessage).delete()
+    s.commit()
+    sm.close_guard()
+
+# ---------- setup ----------
+sid = mkuser(SENDER)
+rid = mkuser(RECIP)
+bid = mkuser(BOT, bot=1)
+oid = mkuser(OTHER)
+wipe_msgs()
+
+# ---------- happy path ----------
+ret = run_worker(udb.do_enqueue_offline_message, sid, RECIP, "hello", False)
+check(ret == ('ok', rid), "enqueue should return ('ok', recipient_id), got %r" % (ret,))
+r = rows(sid, rid)
+check(len(r) == 1, "enqueue should write exactly one row, got %d" % len(r))
+check(r and r[0][1] == "hello", "stored msg should be 'hello', got %r" % (r and r[0][1],))
+check(r and r[0][2] == False, "ex_msg should be False, got %r" % (r and r[0][2],))
+
+# ex_msg is carried through (SAYPRIVATEEX)
+run_worker(udb.do_enqueue_offline_message, sid, RECIP, "waves", True)
+r = rows(sid, rid)
+check(len(r) == 2 and r[1][2] == True, "ex_msg=True should round-trip, got %r" % (r,))
+
+# ---------- unknown user ----------
+ret = run_worker(udb.do_enqueue_offline_message, sid, "phase3_om_ghost", "hi", False)
+check(ret == ('nouser',), "unknown recipient should return ('nouser',), got %r" % (ret,))
+
+# ---------- bots are refused outright, and nothing is written ----------
+ret = run_worker(udb.do_enqueue_offline_message, sid, BOT, "!host map", False)
+check(ret == ('bot',), "bot recipient should return ('bot',), got %r" % (ret,))
+check(len(rows(sid, bid)) == 0, "a message to a bot must not be stored at all")
+
+# ---------- ignore: reported as success, but never written ----------
+s = sm.sess()
+s.add(SQLUsers.Ignore(oid, sid, "no thanks"))  # OTHER ignores SENDER
+s.commit()
+sm.close_guard()
+ret = run_worker(udb.do_enqueue_offline_message, sid, OTHER, "hi", False)
+check(ret == ('ok', oid), "an ignored sender must see success, got %r" % (ret,))
+check(len(rows(sid, oid)) == 0, "an ignored sender's message must never be stored")
+
+# ---------- self-send ----------
+ret = run_worker(udb.do_enqueue_offline_message, sid, SENDER, "note to self", False)
+check(ret == ('nouser',), "self-send should not queue, got %r" % (ret,))
+
+# ---------- per-pair cap: oldest content collapses into one tombstone ----------
+wipe_msgs()
+CAP = SQLUsers.OFFLINE_MSG_MAX_PER_PAIR
+for i in range(CAP):
+    run_worker(udb.do_enqueue_offline_message, sid, RECIP, "m%d" % i, False)
+r = rows(sid, rid)
+check(len(r) == CAP, "should hold exactly %d before the cap bites, got %d" % (CAP, len(r)))
+check(all(x[1] is not None for x in r), "no tombstone should exist before the cap is exceeded")
+
+# one over the cap: still CAP content rows, plus exactly one tombstone
+run_worker(udb.do_enqueue_offline_message, sid, RECIP, "over1", False)
+r = rows(sid, rid)
+content = [x for x in r if x[1] is not None]
+tombs = [x for x in r if x[1] is None]
+check(len(content) == CAP, "cap should hold content at %d, got %d" % (CAP, len(content)))
+check(len(tombs) == 1, "exceeding the cap should create exactly one tombstone, got %d" % len(tombs))
+check(tombs and tombs[0][3] == 1, "tombstone dropped_count should be 1, got %r" % (tombs and tombs[0][3],))
+check(content and content[0][1] == "m1", "oldest content should have been dropped (want m1 first), got %r" % (content and content[0][1],))
+check(content and content[-1][1] == "over1", "newest content should be 'over1', got %r" % (content and content[-1][1],))
+
+# further overflow accumulates into the SAME tombstone, not new ones
+run_worker(udb.do_enqueue_offline_message, sid, RECIP, "over2", False)
+run_worker(udb.do_enqueue_offline_message, sid, RECIP, "over3", False)
+r = rows(sid, rid)
+tombs = [x for x in r if x[1] is None]
+check(len(tombs) == 1, "overflow must collapse into ONE tombstone, got %d" % len(tombs))
+check(tombs and tombs[0][3] == 3, "tombstone should count 3 drops, got %r" % (tombs and tombs[0][3],))
+check(len([x for x in r if x[1] is not None]) == CAP, "content must stay capped at %d" % CAP)
+
+# ---------- fetch resolves the sender username in-query ----------
+wipe_msgs()
+run_worker(udb.do_enqueue_offline_message, sid, RECIP, "first", False)
+run_worker(udb.do_enqueue_offline_message, sid, RECIP, "second", True)
+fetched = run_worker(udb.do_fetch_offline_messages, rid)
+check(len(fetched) == 2, "fetch should return 2 rows, got %d" % len(fetched))
+if len(fetched) == 2:
+    (i0, s0, n0, t0, m0, e0, d0) = fetched[0]
+    check(n0 == SENDER, "fetch should resolve the sender username, got %r" % (n0,))
+    check(m0 == "first", "fetch should be ordered by id (want 'first'), got %r" % (m0,))
+    check(e0 == False, "ex_msg should round-trip as False, got %r" % (e0,))
+    check(isinstance(t0, datetime), "fetch should return a datetime, got %r" % (type(t0),))
+    check(fetched[1][4] == "second" and fetched[1][5] == True, "second row should be the ex_msg, got %r" % (fetched[1],))
+
+# fetch is scoped to the recipient
+check(run_worker(udb.do_fetch_offline_messages, oid) == [], "fetch must not leak another user's messages")
+
+# ---------- delete-on-delivery ----------
+ids = [f[0] for f in fetched]
+n = run_worker(udb.do_delete_offline_messages, ids)
+check(n == 2, "delete should remove 2 rows, got %r" % (n,))
+check(run_worker(udb.do_fetch_offline_messages, rid) == [], "delivered messages must be gone")
+check(run_worker(udb.do_delete_offline_messages, []) == 0, "empty delete should be a no-op")
+
+# ---------- tombstone survives a fetch/delete cycle only until delivered ----------
+wipe_msgs()
+s = sm.sess()
+s.add(SQLUsers.OfflineMessage(sid, rid, datetime.now() - timedelta(days=30), None, False, 7))
+s.commit()
+sm.close_guard()
+fetched = run_worker(udb.do_fetch_offline_messages, rid)
+check(len(fetched) == 1 and fetched[0][4] is None, "a tombstone should be fetched like any row, got %r" % (fetched,))
+check(fetched and fetched[0][6] == 7, "tombstone dropped_count should survive the fetch, got %r" % (fetched and fetched[0][6],))
+run_worker(udb.do_delete_offline_messages, [fetched[0][0]])
+check(run_worker(udb.do_fetch_offline_messages, rid) == [], "a delivered tombstone must be deleted")
+
+wipe_msgs()
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors:
+        print("  -", e)
+    sys.exit(1)
+print("PASS: offline message workers (enqueue/cap/tombstone/ignore/bot/fetch/delete)")


### PR DESCRIPTION
> **Stacked on #24** — review/merge that first. Until it lands, the diff here includes its three commits; it narrows to five once #24 merges. The dependency is real but small: `_chat_timestamp` and the `jsonchat` flag registration both come from #24.

## Why

You can't message someone who isn't there. `in_SAYPRIVATE` resolved the target and, if they were offline, logged `"user to pm is not online"` and dropped the message — the sender was told **nothing at all**. No error, no echo, no hint. The message simply evaporated.

Now it's queued and delivered next time they log in.

## Shape

Queueing is **unconditional and server-side**, so it works on every lobby — SpringLobby and TASClient included. They get a plain `SAIDPRIVATE` burst on login. The `jsonchat` flag only buys richer delivery, never access to the feature.

What the flag buys is the **timestamp**. Plain `SAIDPRIVATE` has nowhere to put a send time, so an old client can't tell a message sent at 1am from one sent at noon — they all arrive at once looking fresh. A `jsonchat` client gets `JSON SAIDPRIVATE` carrying the original send time in unix microseconds. That's the whole point of the exercise, and it's the assertion the e2e test is built around.

| | Content | Tombstone |
|---|---|---|
| `jsonchat` | `JSON SAIDPRIVATE` + `time` (int µs) | `JSON OFFLINEMESSAGESDROPPED` |
| legacy | `SAIDPRIVATE <sender> <msg>` | `SERVERMSG` plain text |

## Content is transient on purpose

You said you'd rather not store private communications on the server if it can be avoided, so nothing is kept longer than it has to be:

- **deleted on delivery**
- **14 day TTL** — the same window `channel_history` already uses. Private content is not held longer than public chat.
- **50 queued messages per sender-recipient pair**, so one person can't fill the table against someone who never logs in.

## Nothing is dropped silently

Every limit above destroys content, and a recipient who is never told is worse off than one who gets a burst. So whenever content goes, a **tombstone** survives it: `msg IS NULL`, plus a count and the newest send time. The recipient learns someone tried to reach them and can go ask. No message body is retained.

There is **one tombstone per pair**, not per message — 50 expiring messages collapse into one tombstone counting 50. Without that collapse the cure is worse than the disease.

`msg IS NULL` as the marker avoids a status column, which matters because there is no migration mechanism: `create_all` is create-if-not-exists only. **This adds exactly one new table and zero new columns**, so it needs no `ALTER` on a live deployment.

## Refusals

| Case | Result |
|---|---|
| Recipient is a **bot** | `FAILED`, nothing stored |
| Recipient **ignores** sender | Echoed as success, nothing stored |
| Unknown user | Silent (unchanged) |
| DB error | `FAILED`, no echo |

**Bots are refused outright** because the alternative is letting someone stack up commands against an offline autohost and have them all land at once on login.

**The ignore check happens at enqueue**, so an ignored sender's message is never written to disk at all — and the verdict is deliberately indistinguishable from success. Ignore status must not be discoverable by probing. It's re-checked in memory at delivery, since the recipient may have added the ignore while the message sat queued.

The sender is otherwise never told whether a message went out live or was stored. The errback deliberately does **not** echo: telling someone their message is queued when the write failed is the exact failure this design exists to prevent.

## Known limitation

Delivery is **at-most-once**. `client.Send` is buffered and unacknowledged, so a disconnect between the send and the delete landing loses the messages. Properly fixing it needs a client ack command, which I haven't built. Deleting only while the client is still connected narrows the window; it does not close it. The delete errback logs loudly because its failure mode is redelivery — the safe direction, but not one to be silent about.

## Prior art

Worth recording: there is none to reuse. Tachyon's `messaging.md` explicitly refuses the feature ("we're not building whatsapp or discord"). Teiserver has a `direct_messages.delivered` column defaulting to `false`, but the call site hardcodes `delivered: true` and nothing reads it — residue of an intent never implemented. Upstream's `ProtocolDescription.xml` documents `JSON` with no wire format and points readers at uberserver's own `protocol.py`. So `JSON SAIDPRIVATE` is new surface and the field names mirror `JSON SAID` for internal consistency.

## Verification

Full suite against MariaDB: **21 passed, 1 failed** — the known `renameaccounttest` harness bug, identical on master.

Worker tests cover the store directly (enqueue, cap, tombstone collapse, ignore, bot, fetch, delete, expiry); e2e drives real sockets through both dialects. Discrimination-checked by breaking each invariant and confirming the specific assertion fires: the bot refusal, the cap, the tombstone collapse counting, and — the important one — delivering `now()` instead of the stored time, which fails only the timestamp assertion.

## Not built

Ack-based at-least-once delivery; offline DMs to/from bridged users.