### PR TITLE
Add relay compatibility flag ('r')

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -143,6 +143,7 @@ Clients advertise optional protocol capabilities via compatibility flags. Suppor
 | `sp` | `scriptPassword` | scriptPassword included in `JOINEDBATTLE` |
 | `b` | `battleAuth` | `JOINBATTLEACCEPT` / `JOINBATTLEDENIED` (autohosts) — permanently optional |
 | `jsonchat` | `jsonChat` | Microsecond timestamps in JSON chat frames; `JSON SAIDPRIVATE` for queued offline messages — permanently optional |
+| `r` | `relay` | Client understands relay-hosted battles and can ask for TURN credentials (permanently optional) |
 
 `jsonchat` is a progressive enhancement, not a gate: everything it covers still works
 without it, just with less information. See [Channel history](#61-channel-history-getchannelmessages)

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -193,11 +193,13 @@ flag_map = {
 	'sp': 'scriptPassword',  # scriptPassword in JOINEDBATTLE
 	'b':  'battleAuth',      # JOINBATTLEACCEPT/JOINBATTLEDENIED (typically only sent by autohosts)
 	'jsonchat': 'jsonChat',  # microsecond timestamps in JSON chat frames, JSON SAIDPRIVATE
+	'r':  'relay',           # understands relay-hosted battles, can ask for TURN credentials
 }
 # optional flags
 optional_flags = (
 	'b', # only useful to autohosts -> permanently optional
 	'jsonchat', # progressive enhancement: without it chat still works, just without timestamps
+	'r', # only useful to clients that can relay -> permanently optional
 )
 
 # flags for functionality that is now either compulsory or was removed


### PR DESCRIPTION
Adds a compatibility flag for coilbox's relay hosting (design: tomjn/coilbox#1696). A client needs to know before login whether the server has a relay, which is what LISTCOMPFLAGS is for.

This has to merge before any coilbox build starts sending the flag, otherwise the first relay-hosting release would tell its users their client is broken.

'r' goes into both flag_map and optional_flags. _checkCompat treats anything in flag_map but outside optional_flags as mandatory, so without the optional_flags entry every SpringLobby, Chobby and skylobby client not sending 'r' would get a spurious "missing flags" warning.

Also documents the flag in PROTOCOL.md section 4, matching the existing rows.

Closes #26