### PR TITLE
Run a TURN server for relayed battles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ xmlrpc.log*
 /server_email_account.txt
 /server_iphub_xkey.txt
 /server_motd.txt
+/server_turn.txt
 /server_verification_message.txt
 /test.db
 /deps.zip

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ xmlrpc.log*
 /server_motd.txt
 /server_turn.txt
 /server_verification_message.txt
+/turnserver.conf
+/turn_cert.pem
+/turn_pkey.pem
 /test.db
 /deps.zip
 /GeoIP.dat

--- a/Client.py
+++ b/Client.py
@@ -83,6 +83,7 @@ class Client():
 		self.battle_bots = {}
 		self.current_battle = None # battle_id
 		self.pending_battle = None # battle_id
+		self.relayed_host_ip = None # address from RELAYEDHOST, waiting for the next OPENBATTLE
 		self.went_ingame = 0
 		self.spectator = False
 		self.battlestatus = {'ready':'0', 'id':'0000', 'ally':'0000', 'mode':'0', 'sync':'00', 'side':'00', 'handicap':'0000000'}

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -18,11 +18,44 @@ from twisted.internet.threads import deferToThread
 
 separator = '-'*60
 
+# Relay hosting: how long a minted TURN credential stays valid, in seconds.
+# coturn re-checks the expiry embedded in the username on every request including the
+# Refresh that keeps an allocation alive, so a credential that expires mid-game kills a
+# running relay. The relay agent outlives the lobby connection, so nothing can mint a
+# replacement once the launcher has closed. The default is therefore sized against a long
+# game rather than against battle setup. Operators can change it on line 3 of
+# server_turn.txt.
+TURN_DEFAULT_TTL = 12 * 60 * 60
+
 try:
 	from urllib2 import urlopen
 except:
 	# The urllib2 module has been split across several modules in Python 3.0
 	from urllib.request import urlopen
+
+def parse_turn_config(lines):
+	# server_turn.txt:
+	#   line 1: TURN URI, e.g. turn:relay.example.org:3478 (or turns:...:5349 for TLS)
+	#   line 2: static-auth-secret, shared with coturn's use-auth-secret
+	#   line 3: credential lifetime in seconds (optional)
+	# Raises ValueError with an operator-readable message on anything malformed. Half a
+	# config is worse than none: a bad lifetime expires credentials mid-game, and a URI
+	# containing a space produces a reply the client silently drops.
+	lines = [line for line in lines if line and not line.startswith('#')]
+	if len(lines) < 2:
+		raise ValueError('expected at least 2 lines (TURN URI, then shared secret), found %d' % len(lines))
+	uri, secret = lines[0], lines[1]
+	if any(c.isspace() for c in uri):
+		raise ValueError('the TURN URI on line 1 must not contain whitespace')
+	ttl = TURN_DEFAULT_TTL
+	if len(lines) > 2:
+		try:
+			ttl = int(lines[2])
+		except ValueError:
+			raise ValueError('the credential lifetime on line 3 must be a whole number of seconds, found %r' % lines[2])
+		if ttl <= 0:
+			raise ValueError('the credential lifetime on line 3 must be greater than zero, found %d' % ttl)
+	return uri, secret, ttl
 
 class DataHandler:
 
@@ -53,6 +86,9 @@ class DataHandler:
 		self.mail_smtp_port = 587
 		self.mail_smtp_user = None
 		self.mail_smtp_pass = None
+		self.turn_uri = None
+		self.turn_secret = None
+		self.turn_ttl = TURN_DEFAULT_TTL
 		self.trusted_proxies = set([])		
 		
 		self.server = 'TASSERVER'
@@ -140,6 +176,7 @@ class DataHandler:
 		self.ip_type_cache = {} #ip->state (iphub: 0=non-residential, 1=residential, 2=both)
 		self.recent_registrations = {} #ip_address->int
 		self.recent_renames = {} #user_id->int
+		self.recent_turn_credentials = {} #user_id->int
 		self.flood_limits = {
 			'fresh':{'msglength':1000, 'bytespersecond':1000, 'seconds':2}, # also the default
 			'user':{'msglength':10000, 'bytespersecond':2000, 'seconds':10},
@@ -538,6 +575,22 @@ class DataHandler:
 		except Exception as e:
 			logging.info('No server_verification_message.txt found, using defaults: %s' % e)
 
+		# relay hosting. Reset first so a reload that finds the file gone also stops
+		# advertising the 'r' compat flag, rather than keeping a stale secret in memory.
+		self.turn_uri = None
+		self.turn_secret = None
+		self.turn_ttl = TURN_DEFAULT_TTL
+		try:
+			with open('server_turn.txt', 'r') as f:
+				file_lines = [l.strip() for l in f.readlines()]
+			self.turn_uri, self.turn_secret, self.turn_ttl = parse_turn_config(file_lines)
+			# never log the secret
+			logging.info('Relay hosting enabled: TURN %s, credential lifetime %ds' % (self.turn_uri, self.turn_ttl))
+		except FileNotFoundError:
+			logging.info('No server_turn.txt found, relay hosting is disabled.')
+		except Exception as e:
+			logging.error('Could not load server_turn.txt, relay hosting is disabled: %s' % e)
+
 		
 		try:
 			if self.trusted_proxyfile:
@@ -759,6 +812,13 @@ class DataHandler:
 
 	def decrement_recent_renames(self):
 		self.decrement_dict(self.recent_renames)
+
+	def decrement_recent_turn_credentials(self):
+		self.decrement_dict(self.recent_turn_credentials)
+
+	def turn_enabled(self):
+		# relay hosting needs both halves of coturn's shared-secret scheme
+		return bool(self.turn_uri and self.turn_secret)
 
 	# the sourceClient is only sent for SAY*, and RING commands
 	# 2.1: takes an iterable of client objects directly (channel.user_clients,

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -280,7 +280,7 @@ bots, script_tags, startrects, map/mod/engine, player/spectator limits.
 - Host force-commands: `FORCEALLYNO`, `FORCETEAMNO`, `FORCETEAMCOLOR`,
   `FORCESPECTATORMODE`, `HANDICAP`, `KICKFROMBATTLE`, `RING`.
 
-### 7.1 Relay hosting (`TURNCREDENTIALS`)
+### 7.1 Relay hosting (`TURNCREDENTIALS`, `CLIENTIP`)
 
 A player who cannot forward a port can host through a TURN relay instead. The relay
 allocation is an ordinary public address, so the battle is advertised in `BATTLEOPENED` and
@@ -323,6 +323,42 @@ Failure cases, all reported as `TURNCREDENTIALSFAILED <reason>`:
   matching the `REGISTER` and `RENAMEACCOUNT` limits
 - the server could not build a credential whose fields are free of spaces, which means its
   TURN URI is misconfigured
+
+#### Joiner addresses (`CLIENTIP`)
+
+A TURN relay only forwards traffic from an address the host has already installed a
+permission for. Traffic from any other address is dropped, and neither end is told
+(RFC 5766 section 9.3). So a relay host has to know each joiner's address before that
+joiner's engine sends its first packet, and the joiner cannot supply it: the packets that
+would carry it are the ones being dropped. The lobby is the only party that knows it in time.
+
+```
+S> CLIENTIP <username> <ip>
+```
+
+Sent to the host of a battle, once per join, immediately before the `JOINEDBATTLE` that
+announces the same user. Players, spectators and mid-game joiners are all the same case, and
+a host that gates joins behind `JOINBATTLEREQUEST` (the `b` flag) gets it after it accepts,
+not before. Nothing is sent for the host's own join.
+
+`<ip>` is the address the outside world sees the joiner at, which is what a TURN permission
+has to match. Where the joiner reached the lobby through a trusted proxy that is the address
+it gave at login, not the proxy's, the same choice `JOINBATTLEREQUEST` makes.
+
+There is no port. TURN permissions match on IP alone and ignore the port (RFC 5766
+section 9), so a port here would be a number with nothing to do.
+
+Two conditions, both required, decide whether the host gets this at all:
+- the host advertised `r` at login, so it knows what the message is for
+- the server has a relay configured, the same `server_turn.txt` that gates `TURNCREDENTIALS`
+
+A host meeting neither sees a byte-for-byte unchanged battle. `CLIENTIP` is a strict
+addition, and no existing client receives it.
+
+`CLIENTIPPORT` is a different message and is unchanged. It carries a UDP port for NAT
+punching, is sent only for battles with a `natType` above zero, and needs the joiner to have
+a UDP source port already registered. A relay joiner has none of that, and widening
+`CLIENTIPPORT` to cover it would change what an existing autohost is told.
 
 ---
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -154,7 +154,7 @@ when the server has a TURN relay configured, because a client reads `COMPFLAGS` 
 whether to offer relay hosting at all. It stays in `flag_map` on every server, so a client
 that sends `r` to a server with no relay is never told the flag is unknown: it just gets
 `TURNCREDENTIALSFAILED` if it asks for a credential. See
-[Relay hosting](#71-relay-hosting-turncredentials).
+[Relay hosting](#71-relay-hosting-turncredentials-clientip-relayedhost).
 
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**
@@ -178,7 +178,7 @@ connection holds the listed level (higher levels inherit lower ones in practice 
 | **user — channel** | `CHANNELS`, `CHANNELTOPIC`, `JOIN`, `LEAVE`, `SAY`, `SAYEX`, `SAYPRIVATE`, `SAYPRIVATEEX`, `GETCHANNELMESSAGES` |
 | **user — account** | `GETUSERINFO`, `RENAMEACCOUNT`, `CHANGEPASSWORD`, `CHANGEEMAILREQUEST`, `CHANGEEMAIL`, `RESENDVERIFICATION` |
 | **user — social** | `IGNORE`, `UNIGNORE`, `IGNORELIST`, `FRIENDREQUEST`, `ACCEPTFRIENDREQUEST`, `DECLINEFRIENDREQUEST`, `UNFRIEND`, `FRIENDLIST`, `FRIENDREQUESTLIST` |
-| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON`, `TURNCREDENTIALS` |
+| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON`, `TURNCREDENTIALS`, `RELAYEDHOST` |
 | **user — bridge** | `BRIDGECLIENTFROM`, `UNBRIDGECLIENTFROM`, `JOINFROM`, `LEAVEFROM`, `SAYFROM` |
 | **user — deprecated** | `MUTE`, `MUTELIST`, `SETCHANNELKEY`, `UNMUTE`, `SAYBATTLE`, `SAYBATTLEEX`, `SAYBATTLEPRIVATEEX`, `FORCELEAVECHANNEL`, `GETINGAMETIME` |
 | **mod** | `GETUSERID`, `GETIP`, `FINDIP`, `SETBOTMODE`, `CREATEBOTACCOUNT`, `RESETUSERPASSWORD`, `KICK`, `BAN`, `BANSPECIFIC`, `UNBAN`, `BLACKLIST`, `UNBLACKLIST`, `LISTBANS`, `LISTBLACKLIST` |
@@ -280,7 +280,7 @@ bots, script_tags, startrects, map/mod/engine, player/spectator limits.
 - Host force-commands: `FORCEALLYNO`, `FORCETEAMNO`, `FORCETEAMCOLOR`,
   `FORCESPECTATORMODE`, `HANDICAP`, `KICKFROMBATTLE`, `RING`.
 
-### 7.1 Relay hosting (`TURNCREDENTIALS`, `CLIENTIP`)
+### 7.1 Relay hosting (`TURNCREDENTIALS`, `CLIENTIP`, `RELAYEDHOST`)
 
 A player who cannot forward a port can host through a TURN relay instead. The relay
 allocation is an ordinary public address, so the battle is advertised in `BATTLEOPENED` and
@@ -359,6 +359,59 @@ addition, and no existing client receives it.
 punching, is sent only for battles with a `natType` above zero, and needs the joiner to have
 a UDP source port already registered. A relay joiner has none of that, and widening
 `CLIENTIPPORT` to cover it would change what an existing autohost is told.
+
+#### The battle's address (`RELAYEDHOST`)
+
+A relayed battle lives at a TURN allocation on the relay, which is a public address on a
+machine the host does not own. The server cannot work that out for itself. Everything it knows
+about a host is the connection the host is talking to it on, and for a relayed host that
+connection names the machine nobody can reach, which is the reason the allocation exists. So
+the host has to say.
+
+```
+C> RELAYEDHOST <ip> <port>
+C> OPENBATTLE <type> <natType> <key> <port> ...
+S> RELAYEDHOSTFAILED <reason>
+```
+
+Requires login and the `r` flag. Two plain fields, no tab sentence, and `<ip>` may be IPv4 or
+IPv6. There is no reply on success. The address is held against the connection and consumed by
+that client's next `OPENBATTLE`, which advertises the battle at it in `BATTLEOPENED` instead of
+working an address out from the host's connection. It is then forgotten, so a second
+`OPENBATTLE` is an ordinary battle again. `LEAVEBATTLE` forgets it too, and so does
+disconnecting, so an address can never attach itself to a battle it was not sent for.
+
+`natType` is untouched and stays `0`. A TURN allocation is an ordinary public UDP address, so a
+joining client dials a relayed battle exactly as it dials a direct one. There is nothing here
+for SpringLobby or Chobby to implement, and inventing a NAT mode would have cost every one of
+them a change.
+
+The `<port>` is in this line as well as in `OPENBATTLE`. `OPENBATTLE` is the one the battle is
+advertised at. This one is here because a rebuilt allocation moves the address and the port
+together, and saying so without reopening the battle needs both in one line. Updating a battle
+that is already open is not implemented.
+
+All three of the address translations `BATTLEOPENED` normally does are skipped, including the
+one that hands a joiner the host's LAN address when the two share a WAN address. Two players
+behind one NAT reach a relayed battle through the relay rather than across their own LAN, so
+every recipient is told the same relay address.
+
+Failure cases, all reported as `RELAYEDHOSTFAILED <reason>`, free text meant to be shown to
+whoever is trying to host:
+- the server has no relay configured, in which case `r` is also absent from `COMPFLAGS`
+- the client did not send `r` at login. Unlike `TURNCREDENTIALS`, which hands out something
+  only the caller can use, this decides what everybody else is told to connect to
+- the address is not a public one: loopback, any private or link-local range, carrier-grade
+  NAT, multicast, the documentation ranges, or the lobby server's own address. Both families
+  are covered by the same check
+- the port is not a whole number between 1 and 65535
+
+The server does not check that the address belongs to the relay it minted a credential for.
+`server_turn.txt` holds a URI whose host is usually a name, coturn's `relay-ip` is allowed to
+differ from the address it signals on, and resolving a name inside the command handler would
+stall the reactor.
+
+A client that sends no `RELAYEDHOST` sees a byte-for-byte unchanged battle.
 
 ---
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -149,6 +149,13 @@ Clients advertise optional protocol capabilities via compatibility flags. Suppor
 without it, just with less information. See [Channel history](#61-channel-history-getchannelmessages)
 and [Offline direct messages](#82-offline-direct-messages).
 
+`r` is the one flag the server advertises conditionally. `LISTCOMPFLAGS` includes it only
+when the server has a TURN relay configured, because a client reads `COMPFLAGS` to decide
+whether to offer relay hosting at all. It stays in `flag_map` on every server, so a client
+that sends `r` to a server with no relay is never told the flag is unknown: it just gets
+`TURNCREDENTIALSFAILED` if it asks for a credential. See
+[Relay hosting](#71-relay-hosting-turncredentials).
+
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**
 document `LISTCOMPFLAGS` output and exactly how/when a client declares its flags during
@@ -171,7 +178,7 @@ connection holds the listed level (higher levels inherit lower ones in practice 
 | **user — channel** | `CHANNELS`, `CHANNELTOPIC`, `JOIN`, `LEAVE`, `SAY`, `SAYEX`, `SAYPRIVATE`, `SAYPRIVATEEX`, `GETCHANNELMESSAGES` |
 | **user — account** | `GETUSERINFO`, `RENAMEACCOUNT`, `CHANGEPASSWORD`, `CHANGEEMAILREQUEST`, `CHANGEEMAIL`, `RESENDVERIFICATION` |
 | **user — social** | `IGNORE`, `UNIGNORE`, `IGNORELIST`, `FRIENDREQUEST`, `ACCEPTFRIENDREQUEST`, `DECLINEFRIENDREQUEST`, `UNFRIEND`, `FRIENDLIST`, `FRIENDREQUESTLIST` |
-| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON` |
+| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON`, `TURNCREDENTIALS` |
 | **user — bridge** | `BRIDGECLIENTFROM`, `UNBRIDGECLIENTFROM`, `JOINFROM`, `LEAVEFROM`, `SAYFROM` |
 | **user — deprecated** | `MUTE`, `MUTELIST`, `SETCHANNELKEY`, `UNMUTE`, `SAYBATTLE`, `SAYBATTLEEX`, `SAYBATTLEPRIVATEEX`, `FORCELEAVECHANNEL`, `GETINGAMETIME` |
 | **mod** | `GETUSERID`, `GETIP`, `FINDIP`, `SETBOTMODE`, `CREATEBOTACCOUNT`, `RESETUSERPASSWORD`, `KICK`, `BAN`, `BANSPECIFIC`, `UNBAN`, `BLACKLIST`, `UNBLACKLIST`, `LISTBANS`, `LISTBLACKLIST` |
@@ -272,6 +279,50 @@ bots, script_tags, startrects, map/mod/engine, player/spectator limits.
   `DISABLEUNITS` / `ENABLEUNITS` / `ENABLEALLUNITS`.
 - Host force-commands: `FORCEALLYNO`, `FORCETEAMNO`, `FORCETEAMCOLOR`,
   `FORCESPECTATORMODE`, `HANDICAP`, `KICKFROMBATTLE`, `RING`.
+
+### 7.1 Relay hosting (`TURNCREDENTIALS`)
+
+A player who cannot forward a port can host through a TURN relay instead. The relay
+allocation is an ordinary public address, so the battle is advertised in `BATTLEOPENED` and
+joined like any other direct host. The lobby's only job is to vouch for its own users, which
+it does by minting a credential the relay will accept.
+
+```
+C> TURNCREDENTIALS
+S> TURNCREDENTIALS <uri> <username> <password> <ttl_seconds>
+S> TURNCREDENTIALSFAILED <reason>
+```
+
+Requires login. The success reply is exactly four space-separated fields and none of `uri`,
+`username` or `password` may be empty or contain a space, because a space in any of them
+shifts every field after it. `ttl_seconds` is a plain base-10 integer and comes last, so a
+client can use it to detect a shifted line. The failure reason is the rest of the line and
+may contain spaces. It is free text meant to be shown to a person.
+
+The credential is `draft-uberti-behave-turn-rest-00`, which coturn implements as
+`use-auth-secret`:
+
+```
+username = "<unix expiry timestamp>:<lobby account id>"
+password = base64(hmac_sha1(shared secret, username))
+```
+
+The relay recomputes the HMAC from a `static-auth-secret` it shares with the lobby, so the
+two processes never talk and neither holds session state. The secret is server configuration
+(`server_turn.txt`, see the README) and is never sent to a client.
+
+`ttl_seconds` is how long the credential stays valid, 43200 (12 hours) by default and set by
+the operator. It is sized against a whole game rather than battle setup: coturn re-checks the
+expiry on every refresh of a live allocation, and the relay outlives the lobby connection, so
+a credential that expires part way through ends the game rather than merely blocking new
+allocations.
+
+Failure cases, all reported as `TURNCREDENTIALSFAILED <reason>`:
+- the server has no relay configured, in which case `r` is also absent from `COMPFLAGS`
+- the caller has asked too often, limited to 3 credentials decaying by one every 20 minutes,
+  matching the `REGISTER` and `RENAMEACCOUNT` limits
+- the server could not build a credential whose fields are free of spaces, which means its
+  TURN URI is misconfigured
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ sudo ufw allow 8201/udp
 
 > If you're on a cloud VPS (AWS, Hetzner, DigitalOcean etc.), also open these ports in your cloud provider's firewall or security group.
 
+Running a TURN relay for relay hosting needs more ports than these, including a range. Those are listed separately under [Relay Hosting (TURN)](#relay-hosting-turn), and you only need them if you turn that feature on.
+
 ---
 
 ## 6. Create an Admin User
@@ -475,6 +477,8 @@ a_long_random_string
 
 The TURN server can run anywhere, on this machine or another host. It needs `use-auth-secret` turned on and a `static-auth-secret` set to the same string as line 2. coturn then recomputes each credential itself, so it never talks to the lobby and keeps no session state. Use `turns:` on port 5349 if your relay serves TLS.
 
+This file is only the lobby's half. Running the relay itself, what it costs to run, and how to check it works are in [Relay Hosting (TURN)](#relay-hosting-turn).
+
 Line 3 is the number of seconds a credential stays valid. coturn re-checks the expiry every time the relay refreshes an allocation, so a credential that runs out mid-game cuts that game off. The default of 43200 (12 hours) is sized to outlast a long game, because the relay agent keeps running after the lobby connection has gone and nothing can ask for a replacement.
 
 Treat the secret like a password: anyone who has it can mint credentials for your relay. The server never logs it and never sends it to a client.
@@ -643,6 +647,181 @@ Note that `local_ip` is supplied by the client in its `LOGIN` command and is onl
 
 ---
 
+## Relay Hosting (TURN)
+
+A player who cannot forward a port cannot host a battle. Relay hosting gives them a way round it: they open an allocation on a TURN relay, the battle is advertised at the relay's address, and everyone else joins it exactly as they would join any other host. It is optional. Without it those players can still play, they just cannot host.
+
+There are two halves. The lobby half is [`server_turn.txt`](#server_turntxt---relay-hosting-turn) above, three lines of config. The relay half is a coturn server, and that is what this section is about. You have to run it, and every byte it carries is on your bill.
+
+### The lobby does not care where the relay runs
+
+The lobby never connects to the relay. It mints a credential as an HMAC of a shared secret, and coturn recomputes the same HMAC from its own copy of that secret. Neither process holds state about the other and neither has to be able to reach the other.
+
+That means the relay can be a container alongside the lobby, a second machine in the same rack, or a machine on another continent, and the lobby's configuration is the same three lines in every case. Moving it later is one edit to line 1 of `server_turn.txt` and a lobby restart.
+
+The one thing that has to match is the secret. `static-auth-secret` in the coturn config and line 2 of `server_turn.txt` must be the same string, byte for byte. **Nothing detects a mismatch.** coturn refuses every credential it is handed, every relayed battle fails to start, and the lobby has no idea. Change one, change the other.
+
+### Same machine, or its own?
+
+| | On the lobby machine | On its own host |
+|---|---|---|
+| Cost | One machine, one bill | A second machine, and the relay's bandwidth bill is usually the larger of the two |
+| Relay traffic starving the lobby | Possible. `bps-capacity` is the only thing stopping it | Cannot happen |
+| Taking the machine down | Ends every relayed game in progress | Relayed games carry on |
+| Where you can put it | Wherever the lobby already is | Wherever the players are |
+
+The third row is the one worth thinking about. A relayed battle outlives the lobby connection that started it: the credential is minted once, sized to outlast a whole game, and nothing ever asks for a replacement. Under Compose, `docker compose restart uberserver` leaves the relay alone, but a reboot or a `docker compose down` does not, and on a shared machine that ends games which had nothing to do with the lobby.
+
+Sharing is cheaper and there is nothing wrong with starting there. Splitting is the upgrade, and because the lobby side does not change, it is an upgrade you can make later.
+
+### Where you put it decides the latency players pay
+
+A relayed battle goes host to relay to player, instead of host to player. Every packet pays the trip to the relay and back out again, both ways. A relay close to the players is worth more than a fast one far from them, so put it near the community rather than near yourself.
+
+If the relay is on the lobby machine, you do not get this choice: it lives wherever the lobby lives.
+
+### What it costs
+
+The engine bounds how much a host sends. `LinkOutgoingBandwidth` defaults to 64 KiB per user per second (`rts/System/GlobalConfig.cpp:36-38` in the engine, quoted in [issue #29](https://github.com/ScarylePoo/uberserver/issues/29)). Nothing in this repository has checked the engine source, so treat that figure as coming from the issue rather than from here.
+
+Relayed traffic crosses the relay twice, once in from the host and once out to the player, and that doubling is the whole point of the sum. For the host's outgoing stream at that ceiling:
+
+| Players | Host sends | Relay carries, each direction | Per battle-hour, each direction |
+|---|---|---|---|
+| 8 | 524288 B/s (4.19 Mbit/s) | 524288 B/s | 1.76 GiB |
+| 16 | 1048576 B/s (8.39 Mbit/s) | 1048576 B/s | 3.52 GiB |
+| 32 | 2097152 B/s (16.78 Mbit/s) | 2097152 B/s | 7.03 GiB |
+
+Redo it with your own player count: `players x 65536` bytes per second, in each direction, and multiply by 3600 for an hour. Most hosts bill outbound only, so the last column is the one to price against.
+
+Two things that sum leaves out. Traffic the other way, player to host, crosses the relay too, and there is no sourced figure here for what a client sends, so the real total is higher than the table. And this is a ceiling rather than a measurement: a real battle uses less, often much less.
+
+### Setting it up with Docker Compose
+
+The relay is behind a Compose profile, so it does not start unless you ask for it.
+
+```bash
+cp turnserver.conf.example turnserver.conf
+nano turnserver.conf
+docker compose --profile relay up -d
+```
+
+Copy the file before you bring the service up. Docker creates a directory where a missing bind mount source should be, and coturn then starts with no configuration at all.
+
+`turnserver.conf.example` is commented throughout and every value in it that is a deployment choice is tagged `EXAMPLE`. Work yours out from the sections below rather than shipping the numbers as they stand.
+
+Generate the secret, and put the same string on line 2 of `server_turn.txt`:
+
+```bash
+openssl rand -hex 32
+```
+
+The service uses host networking, because coturn hands out one UDP port per allocation from its `min-port`..`max-port` range and Docker expands a published port range into one forwarding rule per port. If host networking is not available to you, the alternative is written into the comments in `docker-compose.yml`: narrow the range and publish it.
+
+### Setting it up on its own host
+
+Nothing in this repository needs to be on that machine. Copy `turnserver.conf.example` across, edit it, and run coturn however you prefer. The same image, without Compose:
+
+```bash
+docker run -d --name coturn --restart unless-stopped --network host \
+  -v /etc/coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro \
+  coturn/coturn:4.17.2 -c /etc/coturn/turnserver.conf
+```
+
+Or your distribution's own `coturn` package, with the config wherever its service unit looks for it. The settings in the example config were checked against coturn 4.17.2. Run `turnserver --version` and read coturn's own release notes if yours is older.
+
+Then put that machine's hostname in line 1 of `server_turn.txt` on the lobby and restart the lobby. That address has to be a public one: the server refuses to advertise a battle at anything private, and a relay nobody outside can reach is no use anyway.
+
+### Ports and firewall
+
+```bash
+sudo ufw allow 3478/udp
+sudo ufw allow 3478/tcp
+sudo ufw allow 49152:49401/udp   # must match min-port..max-port in turnserver.conf
+```
+
+And, only if you enable TLS:
+
+```bash
+sudo ufw allow 5349/tcp
+sudo ufw allow 5349/udp
+```
+
+> If you're on a cloud VPS (AWS, Hetzner, DigitalOcean etc.), also open these in your cloud provider's firewall or security group.
+
+Say this out loud before you run it: the third line opens a **range**. That is a far bigger hole than the single `8201/udp` the lobby already has open. The example config uses 250 ports. coturn's own default range is `49152`-`65535`, which is 16384 of them, and nothing forces you to take the default. Size the range to the number of concurrent relayed battles you actually want to support, one port each, and open only that.
+
+### Quotas are the only thing between this and free transit
+
+coturn's `user-quota`, `total-quota`, `max-bps` and `bps-capacity` all default to `0`, meaning unlimited (coturn's shipped `turnserver.conf.default`). Left at the defaults, anyone who can register on your lobby can push whatever they like through your relay, to wherever they like, as fast as your link goes. A game is not the only thing that fits down a UDP relay.
+
+There is no correct value for any of them. What there is, is arithmetic:
+
+- **`user-quota`** is concurrent allocations per lobby account. A relayed battle needs one. Leave a little headroom above that: a host whose allocation is refused after a coturn restart builds a new one, and the old one may not have expired yet.
+- **`total-quota`** is concurrent allocations across the server. Keep it at or below the size of your port range, so you run out of quota rather than out of ports.
+- **`max-bps`** is bytes per second per allocation, each direction counted separately. Set it to at least `max players x 65536` from the table above. Set it lower and you silently drop game traffic, which players report as lag rather than as a broken relay.
+- **`bps-capacity`** is bytes per second across the whole server, each direction counted separately. This is the one that stops the relay starving everything else on the machine, and the one that caps your bandwidth bill. Size it from the link you are paying for.
+
+The example config also denies the private address ranges as relay peers. On a shared machine, an unrestricted relay will happily forward to the lobby, the database, and anything else on the private network.
+
+### TLS on 5349
+
+Plain TURN is UDP to port 3478, and some networks will not pass that. TURNS over TLS on 5349 looks like ordinary TLS traffic and gets through more of them, so it is worth having for the players who need it.
+
+It needs a certificate from a CA the players' clients already trust, with a name matching the host in line 1 of `server_turn.txt`. The lobby's self-signed `server.pem` will not do, because a client that checks the chain refuses it. `tls-listening-port`, `cert` and `pkey` are commented out together in the example config. Uncomment all three or none, because coturn logs an error and does not listen if the port is set without a usable certificate.
+
+coturn reads the certificate once, at startup. `SIGHUP` only reopens its log file (`man turnserver`), so renewing means restarting.
+
+### Restarting the relay
+
+A restart is survivable. Per the [findings posted on issue #29](https://github.com/ScarylePoo/uberserver/issues/29) from a client run against coturn 4.17.2, a restarted coturn answers `437` to a refresh for an allocation it has forgotten, and the client responds by building a new allocation and carrying on. A drain answers `403` and is handled the same way.
+
+The catch is the credential. Rebuilding needs the host's credential to still be valid at that moment, and nothing can hand out a replacement once the lobby connection has gone. That is what line 3 of `server_turn.txt` is for, and why its default is 12 hours rather than something tidier.
+
+### Checking it works
+
+coturn ships its own test clients. Run these from somewhere outside your network, not from the relay itself, or you will only prove the firewall is open to yourself.
+
+**Is the relay reachable at all?**
+
+```bash
+turnutils_stunclient -p 3478 relay.example.org
+```
+
+Expect one line naming the address it saw you at, like `IPv4. UDP reflexive addr: 203.0.113.5:63944`. Nothing back means the port is closed or coturn is not running.
+
+**Does a credential work?**
+
+Mint one the same way the lobby does, from line 2 of `server_turn.txt`, and use it to open an allocation. You need an echo peer with a public address for the last part: run `turnutils_peer -p 3480` on some other machine and point `-e` at it.
+
+```bash
+secret=$(sed -n 2p server_turn.txt)
+turnuser="$(( $(date +%s) + 3600 )):1"
+turnpass=$(printf %s "$turnuser" | openssl dgst -sha1 -hmac "$secret" -binary | base64)
+turnutils_uclient -u "$turnuser" -w "$turnpass" -p 3478 -e 203.0.113.9 -r 3480 -n 3 relay.example.org
+```
+
+Expect it to finish with `Total lost packets 0`. That is the whole path working: credential accepted, allocation opened, permission installed, packets relayed both ways.
+
+### Telling the relay, the credential and the firewall apart
+
+| What you see | Where the problem is |
+|---|---|
+| `turnutils_stunclient` gets nothing back | Firewall or coturn. Port 3478 is closed, or the process is not running |
+| `turnutils_stunclient` answers, `turnutils_uclient` says `Cannot complete Allocation`, and coturn logs `check_stun_auth: Cannot find credentials of user <...>` | The credential. `static-auth-secret` and line 2 of `server_turn.txt` are different strings |
+| Allocation succeeds but no packets come back | The allocation port range. It is open to the relay, but not through the firewall in front of it |
+| Everything above passes and battles still fail | Not the relay. Check the lobby advertises `r` in `COMPFLAGS`, which needs `server_turn.txt` to have loaded |
+
+The middle row is the common one, and it is worth knowing that the coturn log line names the username the lobby minted, `<expiry>:<account id>`. If that line is absent entirely, the request never reached coturn and it is the row above.
+
+Follow the relay's own log while you test:
+
+```bash
+docker compose logs -f coturn
+```
+
+---
+
 ## Troubleshooting
 
 **Container keeps restarting**
@@ -659,6 +838,11 @@ docker compose exec uberserver cat /app/server.log
 - Check the advertised address: PM ChanServ `:showip`
 - If it's stale, PM ChanServ `:refreship` (admin) or `docker compose restart uberserver`
 - Full explanation: [Host IP Detection](#host-ip-detection)
+
+**Relayed battles fail to start**
+- Check the lobby loaded its config: `docker compose logs uberserver | grep -i "relay hosting"`
+- Check the relay is running: `docker compose logs -f coturn`
+- Work out which of the three parts is broken: [Telling the relay, the credential and the firewall apart](#telling-the-relay-the-credential-and-the-firewall-apart)
 
 **Need to wipe and start fresh** (deletes all data)
 ```bash

--- a/README.md
+++ b/README.md
@@ -455,6 +455,34 @@ Get a free API key at https://iphub.info — the free tier allows 1,000 checks p
 
 ---
 
+### server_turn.txt - Relay Hosting (TURN)
+
+Lets a player who cannot forward a port host a battle through a TURN relay. When this file is present the server advertises the `r` compatibility flag and answers the `TURNCREDENTIALS` command with a credential the relay will accept.
+
+```
+line 1: TURN URI              (required)
+line 2: shared secret         (required)
+line 3: credential lifetime   (optional, seconds, default 43200)
+```
+
+**Example:**
+
+```
+turn:relay.example.org:3478
+a_long_random_string
+43200
+```
+
+The TURN server can run anywhere, on this machine or another host. It needs `use-auth-secret` turned on and a `static-auth-secret` set to the same string as line 2. coturn then recomputes each credential itself, so it never talks to the lobby and keeps no session state. Use `turns:` on port 5349 if your relay serves TLS.
+
+Line 3 is the number of seconds a credential stays valid. coturn re-checks the expiry every time the relay refreshes an allocation, so a credential that runs out mid-game cuts that game off. The default of 43200 (12 hours) is sized to outlast a long game, because the relay agent keeps running after the lobby connection has gone and nothing can ask for a replacement.
+
+Treat the secret like a password: anyone who has it can mint credentials for your relay. The server never logs it and never sends it to a client.
+
+> If this file is not present, relay hosting is disabled, `r` is left out of `COMPFLAGS`, and `TURNCREDENTIALS` replies `TURNCREDENTIALSFAILED`.
+
+---
+
 ### bad_words.txt — Profanity Filter
 
 A list of words to censor in chat. One word per line. The server replaces matched words with `***` in channels where censoring is enabled.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,46 @@ services:
         soft: 65536
         hard: 65536
 
+  # Optional TURN relay, for players who cannot forward a port and host through
+  # a relay instead. Opt-in: nothing here starts unless you ask for the profile.
+  #
+  #   cp turnserver.conf.example turnserver.conf   # then edit it
+  #   docker compose --profile relay up -d
+  #
+  # Copy the config first. Docker creates a directory in place of a missing bind
+  # mount source, and coturn then starts with no configuration at all.
+  #
+  # The relay does not talk to the lobby and is not on the internal network. The
+  # only thing tying the two together is the shared secret, which has to be the
+  # same string here and on line 2 of server_turn.txt. See the README, under
+  # "Relay Hosting (TURN)", including the case for running this somewhere else
+  # entirely rather than on the lobby machine.
+  coturn:
+    profiles:
+      - relay
+    image: coturn/coturn:4.17.2
+    restart: unless-stopped
+    command: ["-c", "/etc/coturn/turnserver.conf"]
+    # Host networking, because coturn hands out one UDP port per allocation from
+    # the min-port..max-port range in its config, and Docker expands a published
+    # port range into one forwarding rule per port. Publishing coturn's default
+    # 16384 port range that way is not something to do casually.
+    #
+    # If host networking is not available to you, drop this line, narrow
+    # min-port/max-port to something you have sized, and publish that range:
+    #   ports:
+    #     - "3478:3478/udp"
+    #     - "3478:3478/tcp"
+    #     - "49152-49401:49152-49401/udp"
+    network_mode: host
+    volumes:
+      - ./turnserver.conf:/etc/coturn/turnserver.conf:ro
+      # TLS on 5349. Uncomment these with the tls-listening-port, cert and pkey
+      # lines in turnserver.conf, and point them at a certificate the players'
+      # clients trust. Never commit the key.
+      # - ./turn_cert.pem:/etc/coturn/turn_cert.pem:ro
+      # - ./turn_pkey.pem:/etc/coturn/turn_pkey.pem:ro
+
 volumes:
   db_data:
   server_logs:

--- a/protocol/Battle.py
+++ b/protocol/Battle.py
@@ -48,6 +48,14 @@ class Battle(Channel):
 
 		host = self._root.clientFromSession(self.host)
 		if client!=host:
+			# A relay host has to pre-authorise the joiner's address on the TURN server before
+			# the joiner's engine sends anything, because TURN drops traffic from an address it
+			# holds no permission for and tells neither end (RFC 5766 9.3). The joiner cannot
+			# supply the address itself: the packets that would carry it are the dropped ones.
+			# So it goes out first, ahead of JOINEDBATTLE, and only to a host that asked for
+			# relay support on a server that has a relay. Nobody else's conversation changes.
+			if 'r' in host.compat and self._root.turn_enabled():
+				host.Send('CLIENTIP %s %s' % (client.username, self._root.protocol.publicIP(client)))
 			self._root.broadcast('JOINEDBATTLE %s %s' % (self.battle_id, client.username), ignore=set([self.host, client.session_id])) 
 			scriptPassword = client.scriptPassword
 			if scriptPassword and 'sp' in host.compat:

--- a/protocol/Battle.py
+++ b/protocol/Battle.py
@@ -13,6 +13,7 @@ class Battle(Channel):
 		self.type = ''
 		self.natType = ''
 		self.port = 0
+		self.relayed_ip = None # set from RELAYEDHOST when the host is relayed, None otherwise
 
 		self.title = ''
 		self.map = ''

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -8,6 +8,8 @@ import socket
 import logging
 import datetime
 import base64
+import hashlib
+import hmac
 import json
 import traceback
 
@@ -112,6 +114,9 @@ restricted = {
 	'MYSTATUS',
 	'PORTTEST',
 	'JSON',
+	########
+	# relay hosting
+	'TURNCREDENTIALS',
 	########
 	# bridge bots
 	'BRIDGECLIENTFROM',
@@ -3257,13 +3262,60 @@ class Protocol:
 		client.Remove(reason)
 
 	def in_LISTCOMPFLAGS(self, client):
+		# 'r' is how a client learns whether this server offers relay hosting, so it is only
+		# advertised once a TURN server is configured. It stays in flag_map either way: a
+		# client that sends 'r' to a server with no relay must not be told its flag is
+		# unknown, it must simply get a clean TURNCREDENTIALSFAILED if it asks.
 		flags = ""
 		for flag in flag_map:
+			if flag == 'r' and not self._root.turn_enabled():
+				continue
 			if len(flags)>0:
 				flags += " " + flag
 			else:
 				flags = flag
 		client.Send("COMPFLAGS %s" %(flags))
+
+	def in_TURNCREDENTIALS(self, client):
+		'''
+		Request a time-limited TURN credential for relay hosting.
+
+		Replies TURNCREDENTIALS <uri> <username> <password> <ttl_seconds> on success, or
+		TURNCREDENTIALSFAILED <reason> otherwise. The scheme is
+		draft-uberti-behave-turn-rest-00, which coturn implements as use-auth-secret:
+		the username is "<unix expiry>:<lobby account id>" and the password is
+		base64(hmac_sha1(shared secret, username)). coturn recomputes both from the same
+		secret, so it never has to talk to the lobby or hold any session state.
+		'''
+		if not self._root.turn_enabled():
+			client.Send('TURNCREDENTIALSFAILED This server has no relay configured')
+			return
+
+		ttl = self._root.turn_ttl
+		username = '%d:%s' % (int(time.time()) + ttl, client.user_id)
+		password = base64.b64encode(hmac.new(self._root.turn_secret.encode('utf-8'), username.encode('utf-8'), hashlib.sha1).digest()).decode('utf-8')
+		uri = self._root.turn_uri
+
+		# The reply is exactly four space-separated fields and the client refuses the whole
+		# line if any of them is empty or shifted. Whitespace anywhere but the separators
+		# would do that silently, so check rather than trust: the URI comes from operator
+		# config and the account id has been a string on its way here.
+		for field in (uri, username, password):
+			if not field or any(c.isspace() for c in field):
+				logging.error('[%s] <%s>: refusing to send a malformed TURN credential' % (client.session_id, client.username))
+				client.Send('TURNCREDENTIALSFAILED Server could not build a valid credential, please tell an admin')
+				return
+
+		# Rate limit per account, matching in_REGISTER's per-IP limit and in_RENAMEACCOUNT's
+		# per-user one: 3 in flight, decaying by one every 20 minutes (server.py). Stays after
+		# the checks above so a request that got no credential does not burn a slot.
+		recent = self._root.recent_turn_credentials.get(client.user_id, 0)
+		if recent >= 3:
+			client.Send('TURNCREDENTIALSFAILED too many recent credential requests, please try again later')
+			return
+		self._root.recent_turn_credentials[client.user_id] = recent + 1
+
+		client.Send('TURNCREDENTIALS %s %s %s %d' % (uri, username, password, ttl))
 
 	def in_KICK(self, client, username, reason=''):
 		# kick target username from server

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -10,6 +10,7 @@ import datetime
 import base64
 import hashlib
 import hmac
+import ipaddress
 import json
 import traceback
 
@@ -117,6 +118,7 @@ restricted = {
 	########
 	# relay hosting
 	'TURNCREDENTIALS',
+	'RELAYEDHOST',
 	########
 	# bridge bots
 	'BRIDGECLIENTFROM',
@@ -609,6 +611,36 @@ class Protocol:
 			return client.local_ip
 		return client.ip_address
 
+	def _validRelayedHostAddress(self, ip):
+		# Returns (address, reason). RELAYEDHOST lets a client choose what everybody else is
+		# told to connect to, so the address has to be one the rest of the internet can reach
+		# before it goes anywhere near BATTLEOPENED.
+		try:
+			address = ipaddress.ip_address(ip)
+		except ValueError:
+			return None, '%s is not an IP address' % ip
+
+		# is_global is the whole public/not-public test and it covers both families, so IPv6
+		# is not an afterthought here: it is false for loopback, every private range, the
+		# link-local ranges, carrier-grade NAT and the documentation ranges. Multicast is the
+		# one gap in it, and a battle lives at one host rather than a group.
+		if not address.is_global or address.is_multicast:
+			return None, '%s is not a public address, so nobody could join a battle there' % ip
+
+		# The lobby's own address is a public one, and branch 2 of client_AddBattle already
+		# hands it out for port-forwarded hosts. A client naming it for itself would take
+		# that over, so it is refused however the operator has the lobby addressed.
+		for own in (self._root.online_ip, self._root.local_ip):
+			try:
+				if own and ipaddress.ip_address(own) == address:
+					return None, '%s is this lobby server, not a relay' % ip
+			except ValueError:
+				continue
+
+		# Canonical form, not the client's spelling: 2001:DB8::0:1 and 2001:db8::1 are one
+		# address and only one of them should ever reach a joining client.
+		return str(address), ''
+
 	def _validLegacyPasswordSyntax(self, password):
 		# checks if an old-style password is correctly encoded
 		if (not password):
@@ -788,6 +820,8 @@ class Protocol:
 
 		host = self.clientFromSession(battle.host)
 		# IP translation logic:
+		# 0. If the host named a relay address with RELAYEDHOST, that address is the battle,
+		#    for every recipient. Skip the rest.
 		# 1. If the joining client has the same WAN IP as the host, they are on the same LAN.
 		#    Send the host's local/LAN IP so they can connect directly.
 		# 2. If the host is on the same LAN as the lobby server (host's WAN IP matches the
@@ -808,7 +842,15 @@ class Protocol:
 					return False
 			return False
 
-		if host.ip_address == client.ip_address:
+		if battle.relayed_ip:
+			# A relayed battle lives at a TURN allocation on the relay, a public address on a
+			# machine the host does not own. The three branches below all work an address out
+			# from the host's own connection, so all three name the host's machine, which under
+			# a relay is the address nobody can reach. The same-WAN-IP branch included: two
+			# players behind one NAT still reach a relayed battle through the relay rather than
+			# across their own LAN, so there is no recipient this is worth skipping for.
+			translated_ip = battle.relayed_ip
+		elif host.ip_address == client.ip_address:
 			# Same WAN IP - both on same LAN, use host's local IP
 			translated_ip = host.local_ip
 		elif _is_private_ip(host.ip_address) and not _is_private_ip(client.ip_address):
@@ -2223,6 +2265,14 @@ class Protocol:
 		@required.sentence.str title: The battle's title.
 		@required.sentence.str modName: The mod name.
 		'''
+		# Consumed here rather than on the way out, ahead of the LEAVEBATTLE below which also
+		# forgets it, so that an address only ever belongs to the one OPENBATTLE it arrived
+		# with. A host whose OPENBATTLE is refused sends the pair again (coilbox builds both
+		# lines together), and an address that survived a refusal would be a stale one waiting
+		# to attach itself to some later battle.
+		relayed_ip = client.relayed_host_ip
+		client.relayed_host_ip = None
+
 		if client.current_battle:
 			self.in_LEAVEBATTLE(client)
 
@@ -2303,6 +2353,9 @@ class Protocol:
 		battle.type = type
 		battle.natType = natType
 		battle.port = port
+		# Unconditional: a Battle object is reused for the same host's next battle, so a
+		# relayed one must not leave its address behind for a later direct one.
+		battle.relayed_ip = relayed_ip
 		battle.title = title
 		battle.map = map
 		battle.maphash = maphash
@@ -2484,6 +2537,10 @@ class Protocol:
 		'''
 		Leave current battle.
 		'''
+		# A host that walks away without opening the battle it asked for should not have its
+		# relay address waiting for whatever it opens next.
+		client.relayed_host_ip = None
+
 		battle = self.getCurrentBattle(client)
 		if not battle:
 			self.out_FAILED(client, "LEAVEBATTLE", "not in battle")
@@ -3323,6 +3380,54 @@ class Protocol:
 		self._root.recent_turn_credentials[client.user_id] = recent + 1
 
 		client.Send('TURNCREDENTIALS %s %s %s %d' % (uri, username, password, ttl))
+
+	def in_RELAYEDHOST(self, client, ip, port):
+		'''
+		Name the address the next battle this client opens is reachable at.
+
+		Sent immediately before OPENBATTLE by a host whose battle lives at a TURN allocation
+		on the relay rather than on its own machine. The server cannot work that address out:
+		everything it knows about the host is the connection the host is talking to it on, and
+		that is the machine nobody can reach, which is the reason the allocation exists.
+
+		The address is held against the client and consumed by its next OPENBATTLE, so it can
+		never outlive the one battle it was sent for. natType is untouched: a TURN allocation
+		is an ordinary public UDP address and a joining client needs to understand nothing.
+
+		Refused as RELAYEDHOSTFAILED <reason>, free text meant to be read by whoever is
+		trying to host.
+
+		@required.str ip: The relay allocation's address, IPv4 or IPv6.
+		@required.int port: The relay allocation's port. The battle is advertised at the port
+		OPENBATTLE carries. This one is here because a rebuilt allocation moves the address
+		and the port together.
+		'''
+		if not self._root.turn_enabled():
+			client.Send('RELAYEDHOSTFAILED This server has no relay configured')
+			return
+
+		# Unlike TURNCREDENTIALS, which hands out something a client can only use, this
+		# decides what other people are told to connect to. A client that did not ask for
+		# relay support has no business naming its own address.
+		if 'r' not in client.compat:
+			client.Send('RELAYEDHOSTFAILED Your client did not ask for relay support at login')
+			return
+
+		try:
+			port = int(port)
+		except ValueError:
+			client.Send('RELAYEDHOSTFAILED Port is not a number: %s' % port)
+			return
+		if port < 1 or port > 65535:
+			client.Send('RELAYEDHOSTFAILED Port is out of range: 1-65535: %d' % port)
+			return
+
+		address, reason = self._validRelayedHostAddress(ip)
+		if not address:
+			client.Send('RELAYEDHOSTFAILED %s' % reason)
+			return
+
+		client.relayed_host_ip = address
 
 	def in_KICK(self, client, username, reason=''):
 		# kick target username from server

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -600,7 +600,15 @@ class Protocol:
 
 	def _validateIP(self, ipAddress):
 		return self.ipRegex_compiled.match(ipAddress)
-	
+
+	def publicIP(self, client):
+		# The address the rest of the internet sees this client at, which is not always the
+		# address it is connected from: behind a trusted proxy the socket carries the proxy's
+		# address and the client's own arrives in the LOGIN local_ip field (_login_finish_now).
+		if client.ip_address in self._root.trusted_proxies:
+			return client.local_ip
+		return client.ip_address
+
 	def _validLegacyPasswordSyntax(self, password):
 		# checks if an old-style password is correctly encoded
 		if (not password):
@@ -2356,8 +2364,7 @@ class Protocol:
 				client.Send('JOINBATTLEFAILED Waiting for JOINBATTLEACCEPT/JOINBATTLEDENIED from host')
 			else:
 				self.addPendingBattle(client, battle)
-			client_ip = client.local_ip if client.ip_address in self._root.trusted_proxies else client.ip_address
-			host.Send('JOINBATTLEREQUEST %s %s' % (username, client_ip))
+			host.Send('JOINBATTLEREQUEST %s %s' % (username, self.publicIP(client)))
 			return
 		self.removePendingBattle(client)
 		battle.joinBattle(client)

--- a/server.py
+++ b/server.py
@@ -68,6 +68,8 @@ try:
 	recent_registration_loop.start(60*20)
 	recent_rename_loop = task.LoopingCall(_root.decrement_recent_renames)
 	recent_rename_loop.start(60*60*24*7)
+	recent_turn_credential_loop = task.LoopingCall(_root.decrement_recent_turn_credentials)
+	recent_turn_credential_loop.start(60*20)
 
 	# 3.1: size the reactor thread pool for off-reactor DB work (deferToThread).
 	reactor.suggestThreadPoolSize(_root.max_threads)

--- a/tests/integration/joineraddresstest.py
+++ b/tests/integration/joineraddresstest.py
@@ -1,0 +1,166 @@
+"""
+End-to-end tier: joiner addresses (issue #28) against a server with no TURN relay configured.
+
+The shared test server boots without a server_turn.txt, which is the state every existing
+deployment is in, so the property under test here is the negative one: a battle join must look
+exactly as it did before, whether or not the host asked for relay support. The same battle is
+hosted twice, once by a host advertising 'r' and once by a host that does not, and the two
+hosts' received streams are compared line for line rather than merely searched for CLIENTIP.
+
+The configured half, where a relay host is sent CLIENTIP with the joiner's public address, is
+covered in-process by tests/worker/joineraddressworkertest.py, which needs no server and
+cannot be disturbed by whatever config the operator has left in the repository root.
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import HOST, PORT
+import socket, ssl, hashlib, base64, re, time, sys
+
+raw_pw = "secretpw"
+PW = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+HOST_R = "jaddrhostr"
+HOST_PLAIN = "jaddrhostp"
+JOINER = "jaddrjoiner"
+
+# hosting requires TLS (in_OPENBATTLE), and the test server's certificate is self-signed
+CTX = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class Client:
+    def __init__(self):
+        self.s = socket.create_connection((HOST, PORT))
+        self.buf = ""
+        self.read_for(0.5)
+        self.send("STLS")
+        self.read_until("OK", 5)
+        self.s = CTX.wrap_socket(self.s)
+        self.read_for(0.5)
+
+    def send(self, line):
+        self.s.sendall((line + "\n").encode())
+
+    def read_until(self, substr, timeout=8):
+        deadline = time.time() + timeout
+        while substr not in self.buf and time.time() < deadline:
+            self.s.settimeout(max(0.1, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def read_for(self, seconds):
+        """Drain everything that arrives in a fixed window, for streams with no end marker."""
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.s.settimeout(max(0.05, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def close(self):
+        try: self.s.close()
+        except OSError: pass
+
+
+def register(user):
+    c = Client()
+    c.send("REGISTER %s %s" % (user, PW))
+    print("REGISTER %s -> %s" % (user, c.read_until("\n", 5).strip()))
+    c.close()
+
+
+def login(user, flags):
+    c = Client()
+    c.send("LOGIN %s %s 0 * TestClient\t0\t%s" % (user, PW, flags))
+    got = c.read_until("AGREEMENTEND", 10)
+    if "AGREEMENTEND" in got:
+        c.send("CONFIRMAGREEMENT")
+        got += c.read_until("LOGININFOEND", 10)
+    check("LOGININFOEND" in got, "%s should log in, got:\n%s" % (user, got))
+    return c
+
+
+def open_battle(host, title):
+    host.send("OPENBATTLE 0 0 * 8452 8 4660 0 4660 spring\t105.0\tDeltaSiegeDry\t%s\tBA" % title)
+    opened = host.read_for(1.5)
+    battle_id = None
+    for line in opened.splitlines():
+        if line.startswith("BATTLEOPENED "):
+            battle_id = line.split(" ")[1]
+    check(battle_id is not None, "OPENBATTLE should produce a BATTLEOPENED, got:\n%s" % opened)
+    return battle_id
+
+
+def normalise(lines, host_user, battle_id):
+    """Strip the parts that differ by construction: the host's name and the battle id."""
+    out = []
+    for line in lines:
+        if not line.strip():
+            continue
+        line = re.sub(r"__battle__\d+", "BCHAN", line.strip()).replace(host_user, "HOST")
+        out.append(re.sub(r"(?<= )%s(?= |$)" % re.escape(battle_id), "BID", line))
+    return out
+
+
+def hosted_join(host_user, flags):
+    """Host a battle, have the joiner join it, and hand back what the host saw."""
+    host = login(host_user, flags)
+    battle_id = open_battle(host, "relay join test")
+    joiner = login(JOINER, "u sp")
+    joiner.read_for(0.5)
+    host.read_for(0.5)  # discard the joiner's ADDUSER etc, keeping only the join itself
+
+    joiner.send("JOINBATTLE %s" % battle_id)
+    joiner.read_for(1.5)
+    seen = host.read_for(1.5)
+
+    joiner.send("LEAVEBATTLE")
+    joiner.read_for(0.5)
+    joiner.close()
+    host.close()
+    time.sleep(0.5)  # let the server tear the battle down before the next one opens
+    return normalise(seen.splitlines(), host_user, battle_id)
+
+
+for user in (HOST_R, HOST_PLAIN, JOINER):
+    register(user)
+print("waiting 3s for the delayed-registration window...")
+time.sleep(3)
+
+relay_host = hosted_join(HOST_R, "u sp r")
+plain_host = hosted_join(HOST_PLAIN, "u sp")
+print("host with 'r'    ->", relay_host)
+print("host without 'r' ->", plain_host)
+
+check(any(line.startswith("JOINEDBATTLE ") for line in relay_host),
+      "the join should have happened at all, got %r" % (relay_host,))
+check(not any(line.startswith("CLIENTIP ") for line in relay_host),
+      "no relay is configured, so no CLIENTIP should be sent, got %r" % (relay_host,))
+check(relay_host == plain_host,
+      "advertising 'r' must not change the conversation on a relay-less server:\n  %r\n  %r"
+      % (relay_host, plain_host))
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/integration/relayedhosttest.py
+++ b/tests/integration/relayedhosttest.py
@@ -1,0 +1,170 @@
+"""
+End-to-end tier: RELAYEDHOST (issue #32) against a server with no TURN relay configured.
+
+The shared test server boots without a server_turn.txt, which is the state every existing
+deployment is in, so the properties under test here are the negative ones. RELAYEDHOST is
+refused with a reason somebody can read, and the battle that follows is advertised exactly as
+it would have been if the line had never been sent. Two battles are opened, one by a host that
+sends RELAYEDHOST and one by a host that does not, and what an onlooker is told about each is
+compared line for line.
+
+The configured half, where the battle is advertised at the relay for every recipient, is
+covered in-process by tests/worker/relayedhostworkertest.py, which needs no server and cannot
+be disturbed by whatever config the operator has left in the repository root.
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import HOST, PORT
+import socket, ssl, hashlib, base64, re, time, sys
+
+raw_pw = "secretpw"
+PW = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+HOST_R = "rhosthostr"
+HOST_PLAIN = "rhosthostp"
+WATCHER = "rhostwatcher"
+RELAY_IP = "185.199.108.153"  # a real public address: the documentation ranges are refused
+
+# hosting requires TLS (in_OPENBATTLE), and the test server's certificate is self-signed
+CTX = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class Client:
+    def __init__(self):
+        self.s = socket.create_connection((HOST, PORT))
+        self.buf = ""
+        self.read_for(0.5)
+        self.send("STLS")
+        self.read_until("OK", 5)
+        self.s = CTX.wrap_socket(self.s)
+        self.read_for(0.5)
+
+    def send(self, line):
+        self.s.sendall((line + "\n").encode())
+
+    def read_until(self, substr, timeout=8):
+        deadline = time.time() + timeout
+        while substr not in self.buf and time.time() < deadline:
+            self.s.settimeout(max(0.1, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def read_for(self, seconds):
+        """Drain everything that arrives in a fixed window, for streams with no end marker."""
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.s.settimeout(max(0.05, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def close(self):
+        try: self.s.close()
+        except OSError: pass
+
+
+def register(user):
+    c = Client()
+    c.send("REGISTER %s %s" % (user, PW))
+    print("REGISTER %s -> %s" % (user, c.read_until("\n", 5).strip()))
+    c.close()
+
+
+def login(user, flags):
+    c = Client()
+    c.send("LOGIN %s %s 0 * TestClient\t0\t%s" % (user, PW, flags))
+    got = c.read_until("AGREEMENTEND", 10)
+    if "AGREEMENTEND" in got:
+        c.send("CONFIRMAGREEMENT")
+        got += c.read_until("LOGININFOEND", 10)
+    check("LOGININFOEND" in got, "%s should log in, got:\n%s" % (user, got))
+    c.login_text = got  # the battle list arrives during login, ahead of LOGININFOEND
+    return c
+
+
+def normalise(line, host_user, battle_id):
+    """Strip the parts that differ by construction: the host's name and the battle id."""
+    line = re.sub(r"__battle__\d+", "BCHAN", line.strip()).replace(host_user, "HOST")
+    return re.sub(r"(?<= )%s(?= |$)" % re.escape(battle_id), "BID", line)
+
+
+def hosted(host_user, flags, relayed):
+    """Open a battle, optionally naming a relay address first, and report what was seen."""
+    host = login(host_user, flags)
+    refusal = ""
+    if relayed:
+        host.send("RELAYEDHOST %s 30001" % RELAY_IP)
+        refusal = host.read_for(1.0).strip()
+
+    host.send("OPENBATTLE 0 0 * 30001 8 4660 0 4660 spring\t105.0\tDeltaSiegeDry\trelayed host test\tBA")
+    opened = host.read_for(1.5)
+    battle_id = None
+    for line in opened.splitlines():
+        if line.startswith("BATTLEOPENED "):
+            battle_id = line.split(" ")[1]
+    check(battle_id is not None, "OPENBATTLE should produce a BATTLEOPENED, got:\n%s" % opened)
+
+    # a client logging in afterwards is told about the battle in the same BATTLEOPENED form,
+    # which is the line a joiner actually dials
+    watcher = login(WATCHER, "u sp")
+    seen = ""
+    for line in watcher.login_text.splitlines():
+        if line.startswith("BATTLEOPENED "):
+            seen = line
+    watcher.close()
+    host.close()
+    time.sleep(0.5)  # let the server tear the battle down before the next one opens
+    return refusal, normalise(seen, host_user, battle_id or "")
+
+
+for user in (HOST_R, HOST_PLAIN, WATCHER):
+    register(user)
+print("waiting 3s for the delayed-registration window...")
+time.sleep(3)
+
+refusal, relay_battle = hosted(HOST_R, "u sp r", relayed=True)
+_, plain_battle = hosted(HOST_PLAIN, "u sp", relayed=False)
+print("RELAYEDHOST reply ->", refusal)
+print("battle after RELAYEDHOST ->", relay_battle)
+print("battle without one      ->", plain_battle)
+
+check(refusal.startswith("RELAYEDHOSTFAILED "),
+      "a server with no relay should refuse RELAYEDHOST, got %r" % (refusal,))
+check(len(refusal.split(" ", 1)[-1]) > 10,
+      "the refusal should carry a reason a person can read, got %r" % (refusal,))
+
+check(relay_battle.startswith("BATTLEOPENED "),
+      "the battle should have been advertised at all, got %r" % (relay_battle,))
+check(RELAY_IP not in relay_battle,
+      "a refused address must not reach the battle, got %r" % (relay_battle,))
+check(relay_battle.split(" ")[3] == "0",
+      "natType should still be 0, got %r" % (relay_battle,))
+check(relay_battle == plain_battle,
+      "a refused RELAYEDHOST must leave the battle exactly as it was:\n  %r\n  %r"
+      % (relay_battle, plain_battle))
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/integration/turnrelaytest.py
+++ b/tests/integration/turnrelaytest.py
@@ -1,0 +1,90 @@
+"""
+End-to-end tier: relay hosting against a server with no TURN relay configured.
+
+The shared test server boots without a server_turn.txt, which is the state every existing
+deployment is in. It must therefore leave 'r' out of COMPFLAGS, still accept 'r' from a
+client that sends it anyway, and answer TURNCREDENTIALS with a readable refusal rather than
+a compatibility complaint or a dropped line.
+
+The configured half of this is covered in-process by tests/worker/turnrelayworkertest.py,
+which needs no server and cannot be disturbed by whatever config the operator has left in
+the repository root.
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import HOST, PORT
+import socket, hashlib, base64, time, sys
+
+user = "relaynoturn"
+raw_pw = "secretpw"
+pw = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+def recv_until(s, substr, timeout=5):
+    s.settimeout(timeout)
+    buf = b""
+    try:
+        while substr.encode() not in buf:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+    except socket.timeout:
+        pass
+    return buf.decode(errors="replace")
+
+s = socket.create_connection((HOST, PORT))
+recv_until(s, "\n")
+
+s.sendall(("REGISTER %s %s\n" % (user, pw)).encode())
+print("REGISTER ->", recv_until(s, "\n").strip())
+
+print("waiting 3s for the delayed-registration window...")
+time.sleep(3)
+
+# log in advertising 'r' alongside the mandatory flags. A server with no relay must not
+# complain about it: the flag is known everywhere, it is only advertised conditionally.
+s.sendall(("LOGIN %s %s 0 * TestClient\t0\tu sp r\n" % (user, pw)).encode())
+login = recv_until(s, "AGREEMENTEND")
+if "AGREEMENTEND" in login:
+    s.sendall(b"CONFIRMAGREEMENT\n")
+    login += recv_until(s, "LOGININFOEND")
+check("LOGININFOEND" in login, "login should complete, got:\n%s" % login)
+check("compatibility errors" not in login,
+      "sending 'r' to a relay-less server must not raise a compatibility warning, got:\n%s" % login)
+
+s.sendall(b"LISTCOMPFLAGS\n")
+compflags = ""
+for line in recv_until(s, "COMPFLAGS").splitlines():
+    if line.startswith("COMPFLAGS"):
+        compflags = line
+print("LISTCOMPFLAGS ->", compflags)
+flags = compflags.split()[1:]
+check(compflags != "", "the server should answer LISTCOMPFLAGS")
+check("r" not in flags, "'r' must not be advertised with no relay configured, got %r" % (flags,))
+check("u" in flags and "sp" in flags, "the other flags should still be advertised, got %r" % (flags,))
+
+s.sendall(b"TURNCREDENTIALS\n")
+reply = ""
+for line in recv_until(s, "TURNCREDENTIALS").splitlines():
+    if line.startswith("TURNCREDENTIALS"):
+        reply = line
+print("TURNCREDENTIALS ->", reply)
+check(reply.startswith("TURNCREDENTIALSFAILED "),
+      "a relay-less server should refuse cleanly, got %r" % (reply,))
+check(len(reply.split(" ", 1)[1].strip()) > 0 if " " in reply else False,
+      "the refusal should carry a reason, got %r" % (reply,))
+check("failed. Unknown command" not in reply and "Insufficient rights" not in reply,
+      "TURNCREDENTIALS should be a known command available to a logged-in user, got %r" % (reply,))
+
+s.close()
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/worker/joineraddressworkertest.py
+++ b/tests/worker/joineraddressworkertest.py
@@ -1,0 +1,180 @@
+"""
+Worker-unit test for joiner addresses (issue #28): the CLIENTIP line a relay host is sent
+when somebody joins its battle. Runs the real Battle.joinBattle in-process against fake
+clients, no server and no DB needed.
+
+The property that matters most is the negative one. A host that knows nothing about relays
+must see exactly the conversation it saw before, so every case here compares the host's whole
+received stream against a baseline host, rather than only asserting that CLIENTIP is absent.
+
+Run: activate the venv, then python3 tests/worker/joineraddressworkertest.py
+"""
+import os as _os, sys as _sys
+_ROOT = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir))
+_sys.path[:0] = [_ROOT, _os.path.join(_ROOT, "protocol"),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+import sys
+
+from protocol import Protocol as ProtocolModule
+from protocol.Battle import Battle
+
+PROXY = "10.0.0.1"
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class FakeRoot:
+    def __init__(self, relay=True):
+        self.turn_uri = "turn:relay.example.org:3478" if relay else None
+        self.turn_secret = "a_long_random_string" if relay else None
+        self.trusted_proxies = set([PROXY])
+        self.sessions = {}
+        self.broadcasts = []
+        self.SayHooks = None
+        self.protocol = ProtocolModule.Protocol(self)
+    def turn_enabled(self):
+        return bool(self.turn_uri and self.turn_secret)
+    def clientFromSession(self, session_id):
+        return self.sessions.get(session_id)
+    def clientFromID(self, user_id, fromdb=False):
+        return None
+    def broadcast(self, message, chan=None, ignore=set(), state=None, flag=None, not_flag=None):
+        self.broadcasts.append(message)
+    def getUserDB(self): pass
+    def getVerificationDB(self): pass
+    def getBanDB(self): pass
+    def getContentDB(self): pass
+
+
+class FakeClient:
+    _next_session = 1
+    def __init__(self, root, username, compat=("u", "sp"), ip="203.0.113.7", local_ip=None):
+        self.sent = []
+        self.username = username
+        self.compat = set(compat)
+        self.ip_address = ip
+        self.local_ip = local_ip if local_ip else ip
+        self.session_id = FakeClient._next_session
+        FakeClient._next_session += 1
+        self.static = True  # skips Channel.recordUse, which wants a db
+        self.channels = set()
+        self.battle_bots = {}
+        self.scriptPassword = None
+        self.current_battle = None
+        self.hostport = None
+        self.udpport = None
+        self.battlestatus = {'ready':'0', 'id':'0000', 'ally':'0000', 'mode':'0',
+                             'sync':'00', 'side':'00', 'handicap':'0000000'}
+        self.teamcolor = '0'
+        root.sessions[self.session_id] = self
+    def Send(self, data, command=None):
+        self.sent.append(data)
+
+
+def open_battle(root, host):
+    battle = Battle(root, "__battle__0")
+    battle.battle_id = 0
+    battle.hashcode = 0
+    battle.natType = 0
+    battle.host = host.session_id
+    battle.joinBattle(host)
+    host.sent = []
+    return battle
+
+
+def join(root, battle, joiner):
+    """Join a battle and hand back what the host received during that join."""
+    host = root.clientFromSession(battle.host)
+    before = len(host.sent)
+    battle.joinBattle(joiner)
+    return host.sent[before:]
+
+
+def clientips(lines):
+    return [line for line in lines if line.split(" ")[0] == "CLIENTIP"]
+
+
+# --- a relay host is told each joiner's address ------------------------------------
+root = FakeRoot()
+host = FakeClient(root, "relayhost", compat=("u", "sp", "r"))
+battle = open_battle(root, host)
+
+first = join(root, battle, FakeClient(root, "joiner1"))
+check(clientips(first) == ["CLIENTIP joiner1 203.0.113.7"],
+      "a relay host should be told the joiner's address, got %r" % (first,))
+
+# ahead of JOINEDBATTLE: the host has the address in hand by the time it hears about the join
+if clientips(first):
+    joined = [i for i, line in enumerate(first) if line.startswith("JOINEDBATTLE ")]
+    check(joined and first.index(clientips(first)[0]) < joined[0],
+          "CLIENTIP should arrive before JOINEDBATTLE, got %r" % (first,))
+
+# a second joiner, mid-game or spectating, is the same case: joins run through one path
+second = join(root, battle, FakeClient(root, "joiner2", ip="203.0.113.9"))
+check(clientips(second) == ["CLIENTIP joiner2 203.0.113.9"],
+      "every later joiner should get the same treatment, got %r" % (second,))
+
+# the host's own join says nothing about the host
+solo_root = FakeRoot()
+solo_host = FakeClient(solo_root, "lonehost", compat=("u", "sp", "r"))
+solo = Battle(solo_root, "__battle__1")
+solo.battle_id = 1
+solo.hashcode = 0
+solo.natType = 0
+solo.host = solo_host.session_id
+solo.joinBattle(solo_host)
+check(clientips(solo_host.sent) == [],
+      "a host joining its own battle should not be sent its own address, got %r" % (solo_host.sent,))
+
+
+# --- the address is the public one, not the LAN one -------------------------------
+root = FakeRoot()
+host = FakeClient(root, "relayhost", compat=("u", "sp", "r"))
+battle = open_battle(root, host)
+
+lan = join(root, battle, FakeClient(root, "lanjoiner", ip="198.51.100.4", local_ip="192.168.1.50"))
+check(clientips(lan) == ["CLIENTIP lanjoiner 198.51.100.4"],
+      "the joiner's public address should be sent, not local_ip, got %r" % (lan,))
+
+# behind a trusted proxy the socket address is the proxy's, and the real one is local_ip
+proxied = join(root, battle, FakeClient(root, "proxiedjoiner", ip=PROXY, local_ip="198.51.100.9"))
+check(clientips(proxied) == ["CLIENTIP proxiedjoiner 198.51.100.9"],
+      "behind a trusted proxy the joiner's own address should be sent, got %r" % (proxied,))
+
+
+# --- nobody else's conversation changes -------------------------------------------
+# The baseline is a host with no 'r' on a server with no relay, which is every deployment
+# before this change. Compare the whole stream, not just the absence of CLIENTIP.
+def conversation(relay, host_compat):
+    root = FakeRoot(relay=relay)
+    FakeClient._next_session = 1  # session ids appear in nothing sent, but keep runs identical
+    host = FakeClient(root, "host", compat=host_compat)
+    battle = open_battle(root, host)
+    return join(root, battle, FakeClient(root, "joiner1"))
+
+baseline = conversation(relay=False, host_compat=("u", "sp"))
+check(clientips(baseline) == [], "the baseline host should get no CLIENTIP, got %r" % (baseline,))
+
+no_flag = conversation(relay=True, host_compat=("u", "sp"))
+check(no_flag == baseline,
+      "a host that did not ask for relay support should see an unchanged conversation:\n  %r\n  %r"
+      % (no_flag, baseline))
+
+no_relay = conversation(relay=False, host_compat=("u", "sp", "r"))
+check(no_relay == baseline,
+      "a server with no relay should send nothing new even to a relay host:\n  %r\n  %r"
+      % (no_relay, baseline))
+
+relayed = conversation(relay=True, host_compat=("u", "sp", "r"))
+check(relayed == ["CLIENTIP joiner1 203.0.113.7"] + baseline,
+      "a relay host's conversation should be the baseline plus one line, got:\n  %r\n  %r"
+      % (relayed, baseline))
+
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("PASS: CLIENTIP reaches a relay host with the joiner's public address, and nobody else's conversation changes")

--- a/tests/worker/relayedhostworkertest.py
+++ b/tests/worker/relayedhostworkertest.py
@@ -1,0 +1,308 @@
+"""
+Worker-unit test for RELAYEDHOST (issue #32): the address a relay host names for its battle.
+Runs the real in_RELAYEDHOST, in_OPENBATTLE and client_AddBattle in-process against fakes, no
+server and no DB needed.
+
+Two properties matter. A relayed battle is advertised at the relay for every recipient, which
+means the same-WAN-IP branch of client_AddBattle has to go as well as the other two: two
+players behind one NAT reach a relayed battle through the relay, not across their own LAN. And
+a battle nobody named an address for is advertised exactly as it was before, so every case
+here is run twice, once with RELAYEDHOST and once without, and the two are compared.
+
+Run: activate the venv, then python3 tests/worker/relayedhostworkertest.py
+"""
+import os as _os, sys as _sys
+_ROOT = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir))
+_sys.path[:0] = [_ROOT, _os.path.join(_ROOT, "protocol"),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+import sys
+
+from protocol import Protocol as ProtocolModule
+
+# A relay allocation is on the public internet, and the documentation ranges (203.0.113.0/24,
+# 198.51.100.0/24, 2001:db8::/32) are not, so they are refused along with everything else
+# nobody can route to. That leaves real addresses as the only way to write these tests.
+RELAY_V4 = "185.199.108.153"
+RELAY_V6 = "2606:4700:4700::1111"
+LOBBY_IP = "192.0.2.1"        # only ever compared against, never advertised
+LOBBY_LAN = "10.0.0.2"
+HOST_WAN = "81.2.69.142"
+HOST_LAN = "192.168.1.10"
+OUTSIDER = "31.13.72.36"
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class FakeChannelDB:
+    """Battles are never registered channels, which is all LEAVEBATTLE asks about."""
+    @staticmethod
+    def registered(channel):
+        return False
+
+
+class FakeSayHooks:
+    @staticmethod
+    def hook_OPENBATTLE(protocol, client, title):
+        return title
+
+
+class FakeRoot:
+    def __init__(self, relay=True):
+        self.turn_uri = "turn:relay.example.org:3478" if relay else None
+        self.turn_secret = "a_long_random_string" if relay else None
+        self.online_ip = LOBBY_IP
+        self.local_ip = LOBBY_LAN
+        self.trusted_proxies = set()
+        self.channels = {}
+        self.battles = {}
+        self.usernames = {}
+        self.sessions = {}
+        self.nextbattle = 0
+        self.broadcasts = []
+        self.SayHooks = FakeSayHooks
+        self.channeldb = FakeChannelDB
+        self.protocol = ProtocolModule.Protocol(self)
+    def turn_enabled(self):
+        return bool(self.turn_uri and self.turn_secret)
+    def clientFromSession(self, session_id):
+        return self.sessions.get(session_id)
+    def clientFromID(self, user_id, fromdb=False):
+        return None
+    def broadcast(self, message, chan=None, ignore=set(), state=None, flag=None, not_flag=None):
+        self.broadcasts.append(message)
+    def getUserDB(self): pass
+    def getVerificationDB(self): pass
+    def getBanDB(self): pass
+    def getContentDB(self): pass
+
+
+class FakeClient:
+    _next_session = 1
+    def __init__(self, root, username, compat=("u", "sp"), ip=HOST_WAN, local_ip=None):
+        self.sent = []
+        self.username = username
+        self.compat = set(compat)
+        self.ip_address = ip
+        self.local_ip = local_ip if local_ip else ip
+        self.user_id = FakeClient._next_session
+        self.session_id = FakeClient._next_session
+        FakeClient._next_session += 1
+        self.static = True  # skips Channel.recordUse, which wants a db
+        self.TLS = True     # in_OPENBATTLE refuses to host without it
+        self.bot = False
+        self.channels = set()
+        self.battle_bots = {}
+        self.scriptPassword = None
+        self.current_battle = None
+        self.pending_battle = None
+        self.relayed_host_ip = None
+        self.hostport = None
+        self.udpport = None
+        self.battlestatus = {'ready':'0', 'id':'0000', 'ally':'0000', 'mode':'0',
+                             'sync':'00', 'side':'00', 'handicap':'0000000'}
+        self.teamcolor = '0'
+        root.sessions[self.session_id] = self
+        root.usernames[username] = self
+    def Send(self, data, command=None):
+        self.sent.append(data)
+
+
+def relayedhost(root, client, ip, port="30001"):
+    """Send RELAYEDHOST and hand back the reply, or "" when it was accepted in silence."""
+    before = len(client.sent)
+    root.protocol.in_RELAYEDHOST(client, ip, port)
+    after = client.sent[before:]
+    return after[0] if after else ""
+
+
+def openbattle(root, host, title="relay test"):
+    root.protocol.in_OPENBATTLE(host, "0", "0", "*", "30001", "8", "4660", "0", "4660",
+                                "spring\t105.0\tDeltaSiegeDry\t%s\tBA" % title)
+
+
+def advertised(client):
+    for line in reversed(client.sent):
+        if line.startswith("BATTLEOPENED "):
+            return line
+    return ""
+
+
+def battle_address(line):
+    """The <ip> field of a BATTLEOPENED, which is field 5."""
+    return line.split(" ")[5] if line else ""
+
+
+# --- what RELAYEDHOST accepts -----------------------------------------------------
+root = FakeRoot()
+host = FakeClient(root, "relayhost", compat=("u", "sp", "r"))
+
+check(relayedhost(root, host, RELAY_V4) == "",
+      "a public IPv4 relay address should be accepted in silence, got %r" % (host.sent,))
+check(host.relayed_host_ip == RELAY_V4,
+      "the address should be held against the client, got %r" % (host.relayed_host_ip,))
+
+check(relayedhost(root, host, RELAY_V6) == "",
+      "a public IPv6 relay address should be accepted, got %r" % (host.sent,))
+check(host.relayed_host_ip == RELAY_V6,
+      "IPv6 should be held as sent, got %r" % (host.relayed_host_ip,))
+
+# one address, one spelling: what reaches a joining client is the canonical form
+relayedhost(root, host, "2606:4700:4700:0000:0000:0000:0000:1111")
+check(host.relayed_host_ip == RELAY_V6,
+      "an expanded IPv6 address should be canonicalised, got %r" % (host.relayed_host_ip,))
+
+
+# --- what it refuses --------------------------------------------------------------
+refusals = [
+    ("127.0.0.1", "loopback"),
+    ("::1", "IPv6 loopback"),
+    ("10.0.0.5", "a private range"),
+    ("192.168.1.10", "a private range"),
+    ("172.16.3.4", "a private range"),
+    ("169.254.7.7", "link-local"),
+    ("100.64.0.1", "carrier-grade NAT"),
+    ("0.0.0.0", "the unspecified address"),
+    ("224.0.0.1", "multicast"),
+    ("fd00::1", "an IPv6 unique-local address"),
+    ("fe80::1", "an IPv6 link-local address"),
+    ("ff02::1", "IPv6 multicast"),
+    ("2001:db8::1", "the IPv6 documentation range"),
+    (LOBBY_IP, "the lobby server's own address"),
+    (LOBBY_LAN, "the lobby server's LAN address"),
+    ("not.an.address", "a string that is not an address"),
+    ("010.0.0.1", "an octal-looking address"),
+    ("", "an empty address"),
+]
+for bad, why in refusals:
+    victim = FakeClient(root, "refused_%s" % why.replace(" ", "_"), compat=("u", "sp", "r"))
+    reply = relayedhost(root, victim, bad)
+    check(reply.startswith("RELAYEDHOSTFAILED "),
+          "%s (%r) should be refused with a reason, got %r" % (why, bad, reply))
+    check(len(reply.split(" ", 1)[-1]) > 10,
+          "%s should be refused with something a person can read, got %r" % (why, reply))
+    check(victim.relayed_host_ip is None,
+          "%s should leave no address behind, got %r" % (why, victim.relayed_host_ip))
+
+for bad_port, why in [("0", "port zero"), ("65536", "a port past the top of the range"),
+                      ("-1", "a negative port"), ("relay", "a port that is not a number")]:
+    victim = FakeClient(root, "badport_%s" % bad_port.strip("-"), compat=("u", "sp", "r"))
+    reply = relayedhost(root, victim, RELAY_V4, port=bad_port)
+    check(reply.startswith("RELAYEDHOSTFAILED "),
+          "%s should be refused, got %r" % (why, reply))
+    check(victim.relayed_host_ip is None,
+          "%s should leave no address behind, got %r" % (why, victim.relayed_host_ip))
+
+# a client that never asked for relay support has no business naming its own address
+noflag = FakeClient(root, "noflaghost")
+reply = relayedhost(root, noflag, RELAY_V4)
+check(reply.startswith("RELAYEDHOSTFAILED "),
+      "a client without the 'r' flag should be refused, got %r" % (reply,))
+check(noflag.relayed_host_ip is None,
+      "a refused client should hold no address, got %r" % (noflag.relayed_host_ip,))
+
+# and neither has anybody, on a server with no relay to be hosted through
+norelay_root = FakeRoot(relay=False)
+norelay_host = FakeClient(norelay_root, "norelayhost", compat=("u", "sp", "r"))
+reply = relayedhost(norelay_root, norelay_host, RELAY_V4)
+check(reply.startswith("RELAYEDHOSTFAILED "),
+      "a server with no relay should refuse RELAYEDHOST, got %r" % (reply,))
+check(norelay_host.relayed_host_ip is None,
+      "a refused client should hold no address, got %r" % (norelay_host.relayed_host_ip,))
+
+
+# --- every recipient is told the relay, whoever they are ---------------------------
+def hosted(relayed, host_ip=HOST_WAN, host_lan=HOST_LAN):
+    """Open a battle, relayed or not, and hand back what each kind of onlooker was told."""
+    FakeClient._next_session = 1  # the battle channel is named after the host's account id
+    root = FakeRoot()
+    host = FakeClient(root, "host", compat=("u", "sp", "r"), ip=host_ip, local_ip=host_lan)
+    # constructing a client registers it, and broadcast_AddBattle tells all of them
+    FakeClient(root, "samewan", ip=host_ip, local_ip="192.168.1.11")
+    FakeClient(root, "outsider", ip=OUTSIDER)
+    if relayed:
+        relayedhost(root, host, RELAY_V4)
+    openbattle(root, host)
+    return {name: advertised(client) for name, client in root.usernames.items()}
+
+relayed = hosted(relayed=True)
+direct = hosted(relayed=False)
+
+for who in ("host", "samewan", "outsider"):
+    check(battle_address(relayed[who]) == RELAY_V4,
+          "%s should be told the relay address, got %r" % (who, relayed[who]))
+
+# the same-WAN branch is the one it would be tempting to keep, so name what it used to do
+check(battle_address(direct["samewan"]) == HOST_LAN,
+      "without a relay a same-WAN joiner still gets the host's LAN address, got %r" % (direct["samewan"],))
+check(battle_address(direct["outsider"]) == HOST_WAN,
+      "without a relay an outsider still gets the host's WAN address, got %r" % (direct["outsider"],))
+
+# a host the lobby thinks is private is branch 2, and it is wrong under a relay as well
+lan_relayed = hosted(relayed=True, host_ip="10.9.9.9", host_lan="10.9.9.9")
+lan_direct = hosted(relayed=False, host_ip="10.9.9.9", host_lan="10.9.9.9")
+check(battle_address(lan_relayed["outsider"]) == RELAY_V4,
+      "a private-looking relay host should still advertise the relay, got %r" % (lan_relayed["outsider"],))
+check(battle_address(lan_direct["outsider"]) == LOBBY_IP,
+      "without a relay a private-looking host is still advertised at the lobby, got %r" % (lan_direct["outsider"],))
+
+# natType is the whole reason this needs no client support
+for who, line in relayed.items():
+    check(line.split(" ")[3] == "0",
+          "%s should be told natType 0 for a relayed battle, got %r" % (who, line))
+
+# everything but the address is the same line it always was
+def without_address(line):
+    fields = line.split(" ")
+    fields[5] = "IP"
+    return " ".join(fields)
+
+for who in ("host", "samewan", "outsider"):
+    check(without_address(relayed[who]) == without_address(direct[who]),
+          "only the address should differ for %s:\n  %r\n  %r" % (who, relayed[who], direct[who]))
+
+
+# --- the address belongs to one battle and no other -------------------------------
+root = FakeRoot()
+host = FakeClient(root, "twicehost", compat=("u", "sp", "r"))
+relayedhost(root, host, RELAY_V4)
+openbattle(root, host, "first")
+check(battle_address(advertised(host)) == RELAY_V4,
+      "the first battle should be relayed, got %r" % (advertised(host),))
+
+host.sent = []
+openbattle(root, host, "second")
+check(battle_address(advertised(host)) == HOST_WAN,
+      "a second battle with no RELAYEDHOST should be advertised at the host, got %r" % (advertised(host),))
+
+# opening a battle while already in one runs LEAVEBATTLE first, which also forgets an
+# address. The one that arrived with this OPENBATTLE has to survive that.
+root = FakeRoot()
+host = FakeClient(root, "rehost", compat=("u", "sp", "r"))
+openbattle(root, host, "direct first")
+relayedhost(root, host, RELAY_V4)
+host.sent = []
+openbattle(root, host, "relayed second")
+check(battle_address(advertised(host)) == RELAY_V4,
+      "reopening as a relay host should advertise the relay, got %r" % (advertised(host),))
+
+# leaving without opening anything drops it, so it cannot attach itself to a later battle
+root = FakeRoot()
+host = FakeClient(root, "leaverhost", compat=("u", "sp", "r"))
+relayedhost(root, host, RELAY_V4)
+root.protocol.in_LEAVEBATTLE(host)
+check(host.relayed_host_ip is None,
+      "LEAVEBATTLE should forget a pending address, got %r" % (host.relayed_host_ip,))
+host.sent = []
+openbattle(root, host, "after leaving")
+check(battle_address(advertised(host)) == HOST_WAN,
+      "a forgotten address should not reach a later battle, got %r" % (advertised(host),))
+
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("PASS: a relayed battle is advertised at the relay for every recipient, and a battle "
+      "with no RELAYEDHOST is advertised exactly as before")

--- a/tests/worker/turnrelayworkertest.py
+++ b/tests/worker/turnrelayworkertest.py
@@ -1,0 +1,202 @@
+"""
+Worker-unit test for relay hosting (issue #27): the server_turn.txt parser and the
+TURNCREDENTIALS command. Runs fully in-process, no server and no DB needed.
+
+The wire contract is fixed by the shipped coilbox client: a success reply is exactly four
+space-separated fields and the client silently drops the line if any of them is empty or
+contains a space, so the field checks here are correctness checks, not tidiness.
+
+The credential itself is draft-uberti-behave-turn-rest-00. This test recomputes the HMAC
+independently of the server code, so a change to how the password is derived fails here
+rather than at a coturn nobody is watching.
+
+Run: activate the venv, then python3 tests/worker/turnrelayworkertest.py
+"""
+import os as _os, sys as _sys
+_ROOT = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir))
+_sys.path[:0] = [_ROOT, _os.path.join(_ROOT, "protocol"),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+import base64
+import hashlib
+import hmac
+import sys
+import time
+
+from DataHandler import TURN_DEFAULT_TTL, parse_turn_config
+from protocol import Protocol as ProtocolModule
+
+URI = "turn:relay.example.org:3478"
+SECRET = "a_long_random_string"
+USER_ID = 4242
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class FakeRoot:
+    """Just the parts of DataHandler that Protocol touches for this command."""
+    def __init__(self, uri=URI, secret=SECRET, ttl=TURN_DEFAULT_TTL):
+        self.turn_uri = uri
+        self.turn_secret = secret
+        self.turn_ttl = ttl
+        self.recent_turn_credentials = {}
+        self.SayHooks = None
+    def turn_enabled(self):
+        return bool(self.turn_uri and self.turn_secret)
+    def getUserDB(self): pass
+    def getVerificationDB(self): pass
+    def getBanDB(self): pass
+    def getContentDB(self): pass
+
+
+class FakeClient:
+    def __init__(self):
+        self.sent = []
+        self.user_id = USER_ID
+        self.session_id = 1
+        self.username = "relaytester"
+    def Send(self, data, command=None):
+        self.sent.append(data)
+
+
+def ask(root):
+    """Send TURNCREDENTIALS and hand back the single reply line."""
+    client = FakeClient()
+    ProtocolModule.Protocol(root).in_TURNCREDENTIALS(client)
+    return client.sent[-1] if client.sent else ""
+
+
+def compflags(root):
+    client = FakeClient()
+    ProtocolModule.Protocol(root).in_LISTCOMPFLAGS(client)
+    return client.sent[-1].split()[1:]
+
+
+# --- the config parser -------------------------------------------------------------
+check(parse_turn_config([URI, SECRET]) == (URI, SECRET, TURN_DEFAULT_TTL),
+      "two lines should parse to (uri, secret, default ttl), got %r" % (parse_turn_config([URI, SECRET]),))
+check(TURN_DEFAULT_TTL == 43200,
+      "the default lifetime should be 12 hours (43200s), got %r" % (TURN_DEFAULT_TTL,))
+check(parse_turn_config([URI, SECRET, "60"])[2] == 60,
+      "line 3 should set the lifetime")
+check(parse_turn_config(["# a comment", "", URI, SECRET]) == (URI, SECRET, TURN_DEFAULT_TTL),
+      "blank and commented lines should be skipped")
+
+def rejects(lines, label):
+    try:
+        parse_turn_config(lines)
+    except ValueError:
+        return
+    errors.append("malformed config should raise ValueError: %s" % label)
+
+rejects([], "empty file")
+rejects([URI], "URI but no secret")
+rejects(["turn:relay example.org:3478", SECRET], "URI containing a space")
+rejects([URI, SECRET, "twelve hours"], "non-numeric lifetime")
+rejects([URI, SECRET, "0"], "zero lifetime")
+rejects([URI, SECRET, "-1"], "negative lifetime")
+
+
+# --- a successful request ----------------------------------------------------------
+root = FakeRoot()
+before = int(time.time())
+reply = ask(root)
+after = int(time.time())
+
+parts = reply.split(" ")
+check(parts[0] == "TURNCREDENTIALS", "success reply should start with TURNCREDENTIALS, got %r" % (reply,))
+check(len(parts) == 5,
+      "reply should be the command plus exactly 4 fields, got %d fields: %r" % (len(parts) - 1, reply))
+
+if len(parts) == 5:
+    _, uri, username, password, ttl_field = parts
+    check(uri == URI, "field 1 should be the configured URI, got %r" % (uri,))
+    for name, field in (("uri", uri), ("username", username), ("password", password)):
+        check(field != "", "%s must not be empty" % name)
+        check(not any(c.isspace() for c in field), "%s must not contain whitespace: %r" % (name, field))
+
+    # ttl: a plain base-10 integer, and the default lifetime
+    check(ttl_field == str(TURN_DEFAULT_TTL),
+          "ttl field should be %d, got %r" % (TURN_DEFAULT_TTL, ttl_field))
+    check(ttl_field.isdigit() and int(ttl_field) == TURN_DEFAULT_TTL,
+          "ttl field must parse as a plain integer, got %r" % (ttl_field,))
+
+    # username: "<unix expiry>:<account id>", expiring one lifetime from now
+    check(username.count(":") == 1, "username should be '<expiry>:<account id>', got %r" % (username,))
+    expiry_str, uid_str = username.split(":")
+    check(uid_str == str(USER_ID), "username should carry the account id, got %r" % (uid_str,))
+    expiry = int(expiry_str)
+    check(before + TURN_DEFAULT_TTL <= expiry <= after + TURN_DEFAULT_TTL,
+          "expiry should be now + %ds, got %d (now was %d..%d)" % (TURN_DEFAULT_TTL, expiry, before, after))
+
+    # password: recomputed here rather than trusted
+    expected = base64.b64encode(
+        hmac.new(SECRET.encode("utf-8"), username.encode("utf-8"), hashlib.sha1).digest()).decode("utf-8")
+    check(password == expected,
+          "password should be base64(hmac_sha1(secret, username)), got %r, expected %r" % (password, expected))
+    check(password != base64.b64encode(
+        hmac.new(b"wrong_secret", username.encode("utf-8"), hashlib.sha1).digest()).decode("utf-8"),
+        "password must depend on the configured secret")
+
+
+# --- the lifetime is the operator's, not a constant --------------------------------
+short = FakeRoot(ttl=90)
+before = int(time.time())
+parts = ask(short).split(" ")
+check(len(parts) == 5 and parts[4] == "90", "a configured lifetime should reach the wire, got %r" % (parts,))
+if len(parts) == 5:
+    check(int(parts[2].split(":")[0]) - before == 90,
+          "expiry should move with the configured lifetime, got %r" % (parts[2],))
+
+
+# --- rate limit --------------------------------------------------------------------
+root = FakeRoot()
+burst = [ask(root) for _ in range(4)]
+check(all(r.startswith("TURNCREDENTIALS ") for r in burst[:3]),
+      "the first 3 requests should succeed, got %r" % (burst[:3],))
+check(burst[3].startswith("TURNCREDENTIALSFAILED "),
+      "the 4th request in a burst should be refused, got %r" % (burst[3],))
+check(len(burst[3].split(" ", 1)[1].strip()) > 0,
+      "a refusal should carry a reason a person can act on, got %r" % (burst[3],))
+check(root.recent_turn_credentials[USER_ID] == 3,
+      "a refused request should not burn a further slot, counter is %r" % (root.recent_turn_credentials,))
+
+# the counter decays (server.py runs decrement_dict on a loop), and then it works again
+root.recent_turn_credentials[USER_ID] -= 1
+check(ask(root).startswith("TURNCREDENTIALS "), "a decayed counter should allow another credential")
+
+
+# --- no relay configured -----------------------------------------------------------
+for label, root in (("no uri", FakeRoot(uri=None)),
+                    ("no secret", FakeRoot(secret=None)),
+                    ("neither", FakeRoot(uri=None, secret=None))):
+    reply = ask(root)
+    check(reply.startswith("TURNCREDENTIALSFAILED "),
+          "%s should fail cleanly, got %r" % (label, reply))
+
+
+# --- a URI that would shift the fields is refused, not sent ------------------------
+# parse_turn_config rejects this at startup, so reaching it means the config was set some
+# other way. Either way a malformed success line must never go out.
+reply = ask(FakeRoot(uri="turn:relay example.org:3478"))
+check(reply.startswith("TURNCREDENTIALSFAILED "),
+      "a URI containing a space should be refused, not shifted onto the wire, got %r" % (reply,))
+
+
+# --- LISTCOMPFLAGS advertises 'r' only when there is a relay -----------------------
+configured = compflags(FakeRoot())
+unconfigured = compflags(FakeRoot(uri=None, secret=None))
+check("r" in configured, "COMPFLAGS should advertise 'r' when a relay is configured, got %r" % (configured,))
+check("r" not in unconfigured, "COMPFLAGS should omit 'r' when no relay is configured, got %r" % (unconfigured,))
+check([f for f in configured if f != "r"] == unconfigured,
+      "only 'r' should differ between the two, got %r vs %r" % (configured, unconfigured))
+check("r" in ProtocolModule.flag_map and "r" in ProtocolModule.optional_flags,
+      "'r' must stay a known optional flag on every server, whatever the config")
+
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("PASS: server_turn.txt parses, TURNCREDENTIALS mints a valid credential, and 'r' is advertised only when configured")

--- a/turnserver.conf.example
+++ b/turnserver.conf.example
@@ -1,0 +1,146 @@
+# ── coturn config for uberserver relay hosting ────────────────────────────────
+#
+# Copy this to turnserver.conf and edit it before you run anything:
+#
+#     cp turnserver.conf.example turnserver.conf
+#
+# turnserver.conf is gitignored, because the finished file holds your shared
+# secret. This example file must never hold a real one.
+#
+# Every value tagged EXAMPLE below is a deployment choice with no correct
+# answer. The arithmetic for working out your own is in the README, under
+# "Relay Hosting (TURN)". Do not ship these numbers unread.
+#
+# Defaults quoted in the comments are coturn 4.17.2's own, taken from
+# `turnserver -h` and the turnserver.conf.default shipped with it. Check them
+# against your version.
+
+# ── Listening ─────────────────────────────────────────────────────────────────
+
+# Plain STUN/TURN over UDP and TCP. coturn's default is 3478, and the turn: URI
+# on line 1 of the lobby's server_turn.txt has to name the same port.
+listening-port=3478
+
+# EXAMPLE. Left unset, coturn listens on every address it finds. Set it if the
+# machine has several addresses and you want the relay on one of them.
+#listening-ip=203.0.113.10
+
+# Set this if the relay is behind NAT, which includes most cloud VPS instances
+# with a mapped public address. Left unset, coturn signals the address it is
+# bound to, and if that is the private one the allocation is unreachable. The
+# NAT has to forward each relay port to the same port number.
+#external-ip=203.0.113.10
+#external-ip=203.0.113.10/10.0.0.5
+
+# EXAMPLE. coturn needs a realm for long-term credentials. The value is not part
+# of the credential the lobby mints, so anything works; the relay's own hostname
+# is the usual choice. Without one coturn falls back to the host domain name.
+realm=relay.example.org
+
+# ── Credentials ───────────────────────────────────────────────────────────────
+
+# The lobby mints credentials with draft-uberti-behave-turn-rest-00 and coturn
+# recomputes the same HMAC from the secret below, so the two processes never
+# talk to each other and neither keeps session state.
+use-auth-secret
+
+# MUST be byte for byte the same string as line 2 of the lobby's
+# server_turn.txt. Nothing anywhere detects a mismatch. coturn answers 401 to
+# every credential and every relayed battle fails to start.
+#
+# Generate one:  openssl rand -hex 32
+static-auth-secret=REPLACE_ME_BEFORE_USE
+
+# ── Allocation port range ─────────────────────────────────────────────────────
+
+# One UDP port per allocation, one allocation per relayed battle, so the size of
+# this range is your ceiling on concurrent relayed battles.
+#
+# coturn's defaults are min-port=49152 and max-port=65535, per RFC 5766, which
+# is 16384 ports. Every port in the range has to be open in the firewall, so a
+# range you have sized deliberately is easier to operate than the default one.
+#
+# EXAMPLE, 250 ports for 250 concurrent relayed battles:
+min-port=49152
+max-port=49401
+
+# ── Quotas ────────────────────────────────────────────────────────────────────
+#
+# All four of these default to 0, meaning unlimited. Unlimited is what makes an
+# open relay: anyone holding an account on your lobby can use it as free transit
+# for whatever they like, and nothing in the game caps them. Set all four.
+
+# Concurrent allocations per lobby account. One relayed battle needs one.
+# Leave headroom above that: a host whose allocation is refused after a coturn
+# restart builds a new one, and the old one may not have expired yet.
+#
+# EXAMPLE:
+user-quota=2
+
+# Concurrent allocations across the whole server. Keep this at or below the size
+# of the port range above, so you run out of quota rather than out of ports.
+#
+# EXAMPLE, matching the 250 port range above:
+total-quota=250
+
+# Bytes per second per allocation, counted separately for each direction. This
+# is the setting that stops one session saturating the link. Size it from the
+# engine's own ceiling, worked out in the README: 1048576 B/s covers a 16 player
+# battle. Set it below what a battle actually needs and you silently drop game
+# traffic, which looks like lag rather than like a misconfiguration.
+#
+# EXAMPLE, 16 players:
+max-bps=1048576
+
+# Bytes per second across the whole server, counted separately for each
+# direction. Size it from what the machine's link and your egress bill can
+# stand, not from a number copied out of here.
+#
+# EXAMPLE, 20 concurrent 16 player battles:
+bps-capacity=20971520
+
+# ── Peers ─────────────────────────────────────────────────────────────────────
+
+# A relay forwards to any address it can reach unless told otherwise. On a
+# machine shared with the lobby that includes the lobby itself, the database,
+# and everything else on the private network. Deny the private ranges.
+#
+# coturn already denies loopback peers by default. It does not deny anything
+# else. Add your own ranges if the relay sits on a network with more on it.
+no-multicast-peers
+denied-peer-ip=10.0.0.0-10.255.255.255
+denied-peer-ip=172.16.0.0-172.31.255.255
+denied-peer-ip=192.168.0.0-192.168.255.255
+denied-peer-ip=169.254.0.0-169.254.255.255
+denied-peer-ip=100.64.0.0-100.127.255.255
+denied-peer-ip=fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+# TCP relay endpoints (RFC 6062) are on by default. A battle is UDP, so nothing
+# here needs them, and leaving them on is transit you are not using.
+no-tcp-relay
+
+# ── TLS ───────────────────────────────────────────────────────────────────────
+#
+# TURN over TLS and DTLS, worth having for players whose network blocks plain
+# UDP to unusual ports. coturn's default port is 5349. Uncomment all three lines
+# together: set tls-listening-port without a usable certificate and coturn logs
+# an error and does not listen on it.
+#
+# Point cert and pkey at a certificate from a CA the players' clients already
+# trust, whose name matches the host in the URI on line 1 of server_turn.txt.
+# The lobby's own self-signed server.pem is not a substitute: a client that
+# checks the chain will refuse it.
+#
+# coturn reads these once at startup. SIGHUP only reopens the log file, so a
+# renewal needs a restart.
+#
+#tls-listening-port=5349
+#cert=/etc/coturn/turn_cert.pem
+#pkey=/etc/coturn/turn_pkey.pem
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+
+# stdout, so `docker compose logs coturn` shows it. Running coturn outside a
+# container, put a path here instead and set simple-log if logrotate handles it.
+log-file=stdout


### PR DESCRIPTION
Stacks on https://github.com/ScarylePoo/uberserver/pull/36, which stacks on #34, which stacks on #33. Review last.

Closes #29.

The repo-side half only. Nobody has run or paid for a relay, and this does not commit anyone to doing so.

## Why the topology is left open

You said where coturn runs is the operator's call, so nothing here picks one. That is safe rather than a fudge: the lobby's half of relay hosting is a URI and a secret, it never opens a connection to the relay, and neither end holds state about the other. Same three lines of `server_turn.txt` whether coturn is a container next to the lobby or a box on another continent, and moving it later is one edit and a restart. The README says that in a sentence and then covers both cases, including the `docker run` form for a separate host so that path does not assume Compose.

The Compose service is behind a `relay` profile, so it exists without imposing itself. It is deliberately off the `internal` network, because putting it on one would imply a link that is not there.

## Where every number came from

- 64 KiB per user per second: from #29, quoting `rts/System/GlobalConfig.cpp:36-38`. I cannot read the engine source from here and the README attributes it to the issue rather than claiming it as checked.
- Everything in the bandwidth table is arithmetic on that figure, doubled for the two crossings, with the sum shown so an operator can redo it for their own player count. The README also says what the table leaves out: the player-to-host direction, for which there is no sourced figure.
- coturn's `min-port`/`max-port` defaults of 49152-65535, and all four quotas defaulting to 0 meaning unlimited: from `turnserver -h` and the `turnserver.conf.default` shipped with coturn 4.17.2, which is installed on the machine I wrote this on.
- Nothing else in the config template is presented as a recommendation. `user-quota`, `total-quota`, `max-bps` and `bps-capacity` are choices with no correct answer, so the template tags them `EXAMPLE` and the README gives the arithmetic instead.

## What I checked, and what I did not

Ran:

- `ruff check .`, `python protocol/Protocol.py`, `python SQLUsers.py`. All pass.
- `docker compose --profile relay config`. Valid, and `--services` confirms coturn appears only with the profile.
- `turnserver -c turnserver.conf.example` against the local coturn 4.17.2. Parses with no errors or unknown options.
- A credential minted by the exact expression in `Protocol.in_TURNCREDENTIALS` against that coturn with `use-auth-secret`. Allocation opened, 3 packets relayed both ways, 0 lost. With a deliberately wrong password it fails, and coturn logs `check_stun_auth: Cannot find credentials of user <expiry:id>`. That log line is now the secret-mismatch row in the README's triage table, so it is observed rather than guessed.
- That `openssl dgst -sha1 -hmac | base64` produces the same string as the server's Python, since the README hands operators the shell form for testing.
- That `docker compose config` expands a published UDP port range into one mapping per port. That is the reason the service uses host networking.

Did not:

- Stand up a real relay on a public address. Nothing here claims a working deployment, and everything in the README that has not been run is written as what an operator should expect.
- Validate the config inside the `coturn/coturn:4.17.2` image. A sandbox rule blocked the bind mount. I confirmed the image runs turnserver 4.17.2 and takes CLI arguments, and validated the config against the identical version installed locally.

## Still the operator's decision

The four quotas, the size of the allocation port range, whether to enable TLS and get a certificate for it, and where in the world to put the thing. The README gives the arithmetic for each and refuses to invent a value.
