### PR TITLE
Fix renameaccounttest's server.log path so the suite can run clean

### DIFF
--- a/tests/integration/renameaccounttest.py
+++ b/tests/integration/renameaccounttest.py
@@ -18,7 +18,8 @@ TAG = sys.argv[1] if len(sys.argv) > 1 else "r1"
 def enc(raw): return base64.b64encode(hashlib.md5(raw.encode()).digest()).decode()
 PW = enc("secretpw")
 DB = DB_KWARGS
-LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), "server.log")
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+LOG = os.path.join(ROOT, "server.log")
 
 def recv_until(s, substr, timeout=8):
     s.settimeout(timeout); buf = b""


### PR DESCRIPTION
The server always writes server.log to the repository root (DataHandler.py sets logfilename = "server.log", and the working directory is the repo root both when the `server` fixture spawns it in tests/conftest.py and when the script is run directly). renameaccounttest.py instead looked for the log next to itself in tests/integration/, so it raised FileNotFoundError after all its real checks had already passed. Every suite run therefore reported one failure regardless of server behaviour.

## What this changes about test coverage

Until now, the disconnect-mid-rename probe near the bottom of the test - the part that counts new "1020" and "Unhandled Error" lines in server.log across a rename-then-drop burst - had never actually run. It always crashed on the file open before it could count anything, so that check was silently dead. With the path fixed it runs for real, and across every run I did (via pytest, and three direct invocations from different working directories) it reports 0 new 1020/Unhandled Error lines, so no hidden bug turned up.

## Verification

- `ruff check .`, `python protocol/Protocol.py`, `python SQLUsers.py`: all pass.
- `pytest tests/test_integration.py -k renameaccounttest`: passes.
- `renameaccounttest.py` run directly from /tmp, from tests/integration/, and from the repo root: passes from all three, each time reporting `NEW 1020=0, Unhandled=0`.
- Full suite against a freshly wiped uberserver_test database: 22 passed, 0 failed.

Closes #37