### PR TITLE
Promise the order a refused relay address arrives in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ xmlrpc.log*
 /server_email_account.txt
 /server_iphub_xkey.txt
 /server_motd.txt
+/server_turn.txt
 /server_verification_message.txt
 /test.db
 /deps.zip

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ xmlrpc.log*
 /server_motd.txt
 /server_turn.txt
 /server_verification_message.txt
+/turnserver.conf
+/turn_cert.pem
+/turn_pkey.pem
 /test.db
 /deps.zip
 /GeoIP.dat

--- a/Client.py
+++ b/Client.py
@@ -83,6 +83,7 @@ class Client():
 		self.battle_bots = {}
 		self.current_battle = None # battle_id
 		self.pending_battle = None # battle_id
+		self.relayed_host_ip = None # address from RELAYEDHOST, waiting for the next OPENBATTLE
 		self.went_ingame = 0
 		self.spectator = False
 		self.battlestatus = {'ready':'0', 'id':'0000', 'ally':'0000', 'mode':'0', 'sync':'00', 'side':'00', 'handicap':'0000000'}

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -27,6 +27,17 @@ separator = '-'*60
 # server_turn.txt.
 TURN_DEFAULT_TTL = 12 * 60 * 60
 
+# Relay hosting: the shortest credential lifetime a client is known to accept, in seconds.
+# Coilbox refuses to open a relayed battle on anything shorter and says so before anybody
+# joins. The figure is 5083s, the 99th percentile of 18418 real games from api.bar-rts.com
+# covering 22 to 29 August 2026, plus the relay agent's 32 second worst-case rebuild backoff.
+# The derivation is tomjn/coilbox#2091. It has to cover a whole game rather than just the
+# moment of hosting because coturn works the key out once when it creates the session and
+# checks later requests against the key it kept. What ends a game is expiry before the relay
+# has to be rebuilt, because a rebuild opens a new session, the credential is judged again,
+# and a dead one answers 401 (measured against coturn 4.17.2 in tomjn/coilbox#2041).
+TURN_CLIENT_MIN_TTL = 5115
+
 try:
 	from urllib2 import urlopen
 except:
@@ -55,6 +66,10 @@ def parse_turn_config(lines):
 			raise ValueError('the credential lifetime on line 3 must be a whole number of seconds, found %r' % lines[2])
 		if ttl <= 0:
 			raise ValueError('the credential lifetime on line 3 must be greater than zero, found %d' % ttl)
+	# A warning rather than an error: the server's job is to mint what the operator asked
+	# for, and a client other than coilbox may well accept less.
+	if ttl < TURN_CLIENT_MIN_TTL:
+		logging.warning('server_turn.txt line 3 sets a credential lifetime of %ds, below the %ds coilbox requires. Coilbox will refuse to open a relayed battle on a credential this short, so relay hosting will not work for its players. Another client may accept less. See the server_turn.txt section of the README.' % (ttl, TURN_CLIENT_MIN_TTL))
 	return uri, secret, ttl
 
 class DataHandler:

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -18,11 +18,44 @@ from twisted.internet.threads import deferToThread
 
 separator = '-'*60
 
+# Relay hosting: how long a minted TURN credential stays valid, in seconds.
+# coturn re-checks the expiry embedded in the username on every request including the
+# Refresh that keeps an allocation alive, so a credential that expires mid-game kills a
+# running relay. The relay agent outlives the lobby connection, so nothing can mint a
+# replacement once the launcher has closed. The default is therefore sized against a long
+# game rather than against battle setup. Operators can change it on line 3 of
+# server_turn.txt.
+TURN_DEFAULT_TTL = 12 * 60 * 60
+
 try:
 	from urllib2 import urlopen
 except:
 	# The urllib2 module has been split across several modules in Python 3.0
 	from urllib.request import urlopen
+
+def parse_turn_config(lines):
+	# server_turn.txt:
+	#   line 1: TURN URI, e.g. turn:relay.example.org:3478 (or turns:...:5349 for TLS)
+	#   line 2: static-auth-secret, shared with coturn's use-auth-secret
+	#   line 3: credential lifetime in seconds (optional)
+	# Raises ValueError with an operator-readable message on anything malformed. Half a
+	# config is worse than none: a bad lifetime expires credentials mid-game, and a URI
+	# containing a space produces a reply the client silently drops.
+	lines = [line for line in lines if line and not line.startswith('#')]
+	if len(lines) < 2:
+		raise ValueError('expected at least 2 lines (TURN URI, then shared secret), found %d' % len(lines))
+	uri, secret = lines[0], lines[1]
+	if any(c.isspace() for c in uri):
+		raise ValueError('the TURN URI on line 1 must not contain whitespace')
+	ttl = TURN_DEFAULT_TTL
+	if len(lines) > 2:
+		try:
+			ttl = int(lines[2])
+		except ValueError:
+			raise ValueError('the credential lifetime on line 3 must be a whole number of seconds, found %r' % lines[2])
+		if ttl <= 0:
+			raise ValueError('the credential lifetime on line 3 must be greater than zero, found %d' % ttl)
+	return uri, secret, ttl
 
 class DataHandler:
 
@@ -53,6 +86,9 @@ class DataHandler:
 		self.mail_smtp_port = 587
 		self.mail_smtp_user = None
 		self.mail_smtp_pass = None
+		self.turn_uri = None
+		self.turn_secret = None
+		self.turn_ttl = TURN_DEFAULT_TTL
 		self.trusted_proxies = set([])		
 		
 		self.server = 'TASSERVER'
@@ -140,6 +176,7 @@ class DataHandler:
 		self.ip_type_cache = {} #ip->state (iphub: 0=non-residential, 1=residential, 2=both)
 		self.recent_registrations = {} #ip_address->int
 		self.recent_renames = {} #user_id->int
+		self.recent_turn_credentials = {} #user_id->int
 		self.flood_limits = {
 			'fresh':{'msglength':1000, 'bytespersecond':1000, 'seconds':2}, # also the default
 			'user':{'msglength':10000, 'bytespersecond':2000, 'seconds':10},
@@ -538,6 +575,22 @@ class DataHandler:
 		except Exception as e:
 			logging.info('No server_verification_message.txt found, using defaults: %s' % e)
 
+		# relay hosting. Reset first so a reload that finds the file gone also stops
+		# advertising the 'r' compat flag, rather than keeping a stale secret in memory.
+		self.turn_uri = None
+		self.turn_secret = None
+		self.turn_ttl = TURN_DEFAULT_TTL
+		try:
+			with open('server_turn.txt', 'r') as f:
+				file_lines = [l.strip() for l in f.readlines()]
+			self.turn_uri, self.turn_secret, self.turn_ttl = parse_turn_config(file_lines)
+			# never log the secret
+			logging.info('Relay hosting enabled: TURN %s, credential lifetime %ds' % (self.turn_uri, self.turn_ttl))
+		except FileNotFoundError:
+			logging.info('No server_turn.txt found, relay hosting is disabled.')
+		except Exception as e:
+			logging.error('Could not load server_turn.txt, relay hosting is disabled: %s' % e)
+
 		
 		try:
 			if self.trusted_proxyfile:
@@ -759,6 +812,13 @@ class DataHandler:
 
 	def decrement_recent_renames(self):
 		self.decrement_dict(self.recent_renames)
+
+	def decrement_recent_turn_credentials(self):
+		self.decrement_dict(self.recent_turn_credentials)
+
+	def turn_enabled(self):
+		# relay hosting needs both halves of coturn's shared-secret scheme
+		return bool(self.turn_uri and self.turn_secret)
 
 	# the sourceClient is only sent for SAY*, and RING commands
 	# 2.1: takes an iterable of client objects directly (channel.user_clients,

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -280,7 +280,7 @@ bots, script_tags, startrects, map/mod/engine, player/spectator limits.
 - Host force-commands: `FORCEALLYNO`, `FORCETEAMNO`, `FORCETEAMCOLOR`,
   `FORCESPECTATORMODE`, `HANDICAP`, `KICKFROMBATTLE`, `RING`.
 
-### 7.1 Relay hosting (`TURNCREDENTIALS`)
+### 7.1 Relay hosting (`TURNCREDENTIALS`, `CLIENTIP`)
 
 A player who cannot forward a port can host through a TURN relay instead. The relay
 allocation is an ordinary public address, so the battle is advertised in `BATTLEOPENED` and
@@ -323,6 +323,42 @@ Failure cases, all reported as `TURNCREDENTIALSFAILED <reason>`:
   matching the `REGISTER` and `RENAMEACCOUNT` limits
 - the server could not build a credential whose fields are free of spaces, which means its
   TURN URI is misconfigured
+
+#### Joiner addresses (`CLIENTIP`)
+
+A TURN relay only forwards traffic from an address the host has already installed a
+permission for. Traffic from any other address is dropped, and neither end is told
+(RFC 5766 section 9.3). So a relay host has to know each joiner's address before that
+joiner's engine sends its first packet, and the joiner cannot supply it: the packets that
+would carry it are the ones being dropped. The lobby is the only party that knows it in time.
+
+```
+S> CLIENTIP <username> <ip>
+```
+
+Sent to the host of a battle, once per join, immediately before the `JOINEDBATTLE` that
+announces the same user. Players, spectators and mid-game joiners are all the same case, and
+a host that gates joins behind `JOINBATTLEREQUEST` (the `b` flag) gets it after it accepts,
+not before. Nothing is sent for the host's own join.
+
+`<ip>` is the address the outside world sees the joiner at, which is what a TURN permission
+has to match. Where the joiner reached the lobby through a trusted proxy that is the address
+it gave at login, not the proxy's, the same choice `JOINBATTLEREQUEST` makes.
+
+There is no port. TURN permissions match on IP alone and ignore the port (RFC 5766
+section 9), so a port here would be a number with nothing to do.
+
+Two conditions, both required, decide whether the host gets this at all:
+- the host advertised `r` at login, so it knows what the message is for
+- the server has a relay configured, the same `server_turn.txt` that gates `TURNCREDENTIALS`
+
+A host meeting neither sees a byte-for-byte unchanged battle. `CLIENTIP` is a strict
+addition, and no existing client receives it.
+
+`CLIENTIPPORT` is a different message and is unchanged. It carries a UDP port for NAT
+punching, is sent only for battles with a `natType` above zero, and needs the joiner to have
+a UDP source port already registered. A relay joiner has none of that, and widening
+`CLIENTIPPORT` to cover it would change what an existing autohost is told.
 
 ---
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -154,7 +154,7 @@ when the server has a TURN relay configured, because a client reads `COMPFLAGS` 
 whether to offer relay hosting at all. It stays in `flag_map` on every server, so a client
 that sends `r` to a server with no relay is never told the flag is unknown: it just gets
 `TURNCREDENTIALSFAILED` if it asks for a credential. See
-[Relay hosting](#71-relay-hosting-turncredentials-clientip-relayedhost).
+[Relay hosting](#71-relay-hosting-turncredentials-clientip-relayedhost-moverelayedhost).
 
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -386,6 +386,20 @@ working an address out from the host's connection. It is then forgotten, so a se
 `OPENBATTLE` is an ordinary battle again. `LEAVEBATTLE` forgets it too, and so does
 disconnecting, so an address can never attach itself to a battle it was not sent for.
 
+`RELAYEDHOSTFAILED` is written before any answer to the `OPENBATTLE` that follows it on the
+same connection. `in_RELAYEDHOST` replies where the line is read, and the handler for the next
+line runs only after it returns, so a refusal always comes ahead of both `BATTLEOPENED` and the
+`OPENBATTLE` acknowledgement. A client can rely on that to hold a refusal until it knows
+whether the battle opened, which is the only point at which the refusal means anything to the
+person hosting. `tests/integration/relayedhostorderingtest.py` pins it.
+
+Expect both in one read. The two lines answer two lines the client sent back to back, so they
+routinely arrive in a single TCP segment: in that test the refusal and the whole battle-open
+sequence came back in one 405 byte read. A client that keeps the refusal in a slot holding only
+the latest value will have the `OPENBATTLE` acknowledgement overwrite it before anything reads
+it, and will then tell the host their unrelayed battle is relayed, which is the opposite of
+what happened. Record a refusal somewhere the acknowledgement cannot displace.
+
 The server neither reads nor changes `natType`, and a relay host sends `0` like a direct host.
 A TURN allocation is an ordinary public UDP address, so a joining client dials a relayed battle
 exactly as it dials a direct one. There is nothing here for SpringLobby or Chobby to implement,

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -154,7 +154,7 @@ when the server has a TURN relay configured, because a client reads `COMPFLAGS` 
 whether to offer relay hosting at all. It stays in `flag_map` on every server, so a client
 that sends `r` to a server with no relay is never told the flag is unknown: it just gets
 `TURNCREDENTIALSFAILED` if it asks for a credential. See
-[Relay hosting](#71-relay-hosting-turncredentials).
+[Relay hosting](#71-relay-hosting-turncredentials-clientip-relayedhost).
 
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**
@@ -178,7 +178,7 @@ connection holds the listed level (higher levels inherit lower ones in practice 
 | **user — channel** | `CHANNELS`, `CHANNELTOPIC`, `JOIN`, `LEAVE`, `SAY`, `SAYEX`, `SAYPRIVATE`, `SAYPRIVATEEX`, `GETCHANNELMESSAGES` |
 | **user — account** | `GETUSERINFO`, `RENAMEACCOUNT`, `CHANGEPASSWORD`, `CHANGEEMAILREQUEST`, `CHANGEEMAIL`, `RESENDVERIFICATION` |
 | **user — social** | `IGNORE`, `UNIGNORE`, `IGNORELIST`, `FRIENDREQUEST`, `ACCEPTFRIENDREQUEST`, `DECLINEFRIENDREQUEST`, `UNFRIEND`, `FRIENDLIST`, `FRIENDREQUESTLIST` |
-| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON`, `TURNCREDENTIALS` |
+| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON`, `TURNCREDENTIALS`, `RELAYEDHOST` |
 | **user — bridge** | `BRIDGECLIENTFROM`, `UNBRIDGECLIENTFROM`, `JOINFROM`, `LEAVEFROM`, `SAYFROM` |
 | **user — deprecated** | `MUTE`, `MUTELIST`, `SETCHANNELKEY`, `UNMUTE`, `SAYBATTLE`, `SAYBATTLEEX`, `SAYBATTLEPRIVATEEX`, `FORCELEAVECHANNEL`, `GETINGAMETIME` |
 | **mod** | `GETUSERID`, `GETIP`, `FINDIP`, `SETBOTMODE`, `CREATEBOTACCOUNT`, `RESETUSERPASSWORD`, `KICK`, `BAN`, `BANSPECIFIC`, `UNBAN`, `BLACKLIST`, `UNBLACKLIST`, `LISTBANS`, `LISTBLACKLIST` |
@@ -280,7 +280,7 @@ bots, script_tags, startrects, map/mod/engine, player/spectator limits.
 - Host force-commands: `FORCEALLYNO`, `FORCETEAMNO`, `FORCETEAMCOLOR`,
   `FORCESPECTATORMODE`, `HANDICAP`, `KICKFROMBATTLE`, `RING`.
 
-### 7.1 Relay hosting (`TURNCREDENTIALS`, `CLIENTIP`)
+### 7.1 Relay hosting (`TURNCREDENTIALS`, `CLIENTIP`, `RELAYEDHOST`)
 
 A player who cannot forward a port can host through a TURN relay instead. The relay
 allocation is an ordinary public address, so the battle is advertised in `BATTLEOPENED` and
@@ -359,6 +359,59 @@ addition, and no existing client receives it.
 punching, is sent only for battles with a `natType` above zero, and needs the joiner to have
 a UDP source port already registered. A relay joiner has none of that, and widening
 `CLIENTIPPORT` to cover it would change what an existing autohost is told.
+
+#### The battle's address (`RELAYEDHOST`)
+
+A relayed battle lives at a TURN allocation on the relay, which is a public address on a
+machine the host does not own. The server cannot work that out for itself. Everything it knows
+about a host is the connection the host is talking to it on, and for a relayed host that
+connection names the machine nobody can reach, which is the reason the allocation exists. So
+the host has to say.
+
+```
+C> RELAYEDHOST <ip> <port>
+C> OPENBATTLE <type> <natType> <key> <port> ...
+S> RELAYEDHOSTFAILED <reason>
+```
+
+Requires login and the `r` flag. Two plain fields, no tab sentence, and `<ip>` may be IPv4 or
+IPv6. There is no reply on success. The address is held against the connection and consumed by
+that client's next `OPENBATTLE`, which advertises the battle at it in `BATTLEOPENED` instead of
+working an address out from the host's connection. It is then forgotten, so a second
+`OPENBATTLE` is an ordinary battle again. `LEAVEBATTLE` forgets it too, and so does
+disconnecting, so an address can never attach itself to a battle it was not sent for.
+
+`natType` is untouched and stays `0`. A TURN allocation is an ordinary public UDP address, so a
+joining client dials a relayed battle exactly as it dials a direct one. There is nothing here
+for SpringLobby or Chobby to implement, and inventing a NAT mode would have cost every one of
+them a change.
+
+The `<port>` is in this line as well as in `OPENBATTLE`. `OPENBATTLE` is the one the battle is
+advertised at. This one is here because a rebuilt allocation moves the address and the port
+together, and saying so without reopening the battle needs both in one line. Updating a battle
+that is already open is not implemented.
+
+All three of the address translations `BATTLEOPENED` normally does are skipped, including the
+one that hands a joiner the host's LAN address when the two share a WAN address. Two players
+behind one NAT reach a relayed battle through the relay rather than across their own LAN, so
+every recipient is told the same relay address.
+
+Failure cases, all reported as `RELAYEDHOSTFAILED <reason>`, free text meant to be shown to
+whoever is trying to host:
+- the server has no relay configured, in which case `r` is also absent from `COMPFLAGS`
+- the client did not send `r` at login. Unlike `TURNCREDENTIALS`, which hands out something
+  only the caller can use, this decides what everybody else is told to connect to
+- the address is not a public one: loopback, any private or link-local range, carrier-grade
+  NAT, multicast, the documentation ranges, or the lobby server's own address. Both families
+  are covered by the same check
+- the port is not a whole number between 1 and 65535
+
+The server does not check that the address belongs to the relay it minted a credential for.
+`server_turn.txt` holds a URI whose host is usually a name, coturn's `relay-ip` is allowed to
+differ from the address it signals on, and resolving a name inside the command handler would
+stall the reactor.
+
+A client that sends no `RELAYEDHOST` sees a byte-for-byte unchanged battle.
 
 ---
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -319,8 +319,10 @@ allocations.
 
 Failure cases, all reported as `TURNCREDENTIALSFAILED <reason>`:
 - the server has no relay configured, in which case `r` is also absent from `COMPFLAGS`
-- the caller has asked too often, limited to 3 credentials decaying by one every 20 minutes,
-  matching the `REGISTER` and `RENAMEACCOUNT` limits
+- the caller has asked too often. The allowance is 3 credentials, decaying by one every 20
+  minutes, and it is held against the lobby account rather than the connection, so
+  reconnecting does not clear it. `REGISTER` uses the same allowance and the same decay,
+  counted per IP
 - the server could not build a credential whose fields are free of spaces, which means its
   TURN URI is misconfigured
 
@@ -381,15 +383,16 @@ working an address out from the host's connection. It is then forgotten, so a se
 `OPENBATTLE` is an ordinary battle again. `LEAVEBATTLE` forgets it too, and so does
 disconnecting, so an address can never attach itself to a battle it was not sent for.
 
-`natType` is untouched and stays `0`. A TURN allocation is an ordinary public UDP address, so a
-joining client dials a relayed battle exactly as it dials a direct one. There is nothing here
-for SpringLobby or Chobby to implement, and inventing a NAT mode would have cost every one of
-them a change.
+The server neither reads nor changes `natType`, and a relay host sends `0` like a direct host.
+A TURN allocation is an ordinary public UDP address, so a joining client dials a relayed battle
+exactly as it dials a direct one. There is nothing here for SpringLobby or Chobby to implement,
+and inventing a NAT mode would have cost every one of them a change.
 
 The `<port>` is in this line as well as in `OPENBATTLE`. `OPENBATTLE` is the one the battle is
 advertised at. This one is here because a rebuilt allocation moves the address and the port
 together, and saying so without reopening the battle needs both in one line. Updating a battle
-that is already open is not implemented.
+that is already open is not implemented, so today the server range-checks this port and then
+discards it. Send the real one anyway, because an out-of-range value is refused.
 
 All three of the address translations `BATTLEOPENED` normally does are skipped, including the
 one that hands a joiner the host's LAN address when the two share a WAN address. Two players
@@ -401,6 +404,7 @@ whoever is trying to host:
 - the server has no relay configured, in which case `r` is also absent from `COMPFLAGS`
 - the client did not send `r` at login. Unlike `TURNCREDENTIALS`, which hands out something
   only the caller can use, this decides what everybody else is told to connect to
+- the address does not parse as an IP address at all
 - the address is not a public one: loopback, any private or link-local range, carrier-grade
   NAT, multicast, the documentation ranges, or the lobby server's own address. Both families
   are covered by the same check

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -149,6 +149,13 @@ Clients advertise optional protocol capabilities via compatibility flags. Suppor
 without it, just with less information. See [Channel history](#61-channel-history-getchannelmessages)
 and [Offline direct messages](#82-offline-direct-messages).
 
+`r` is the one flag the server advertises conditionally. `LISTCOMPFLAGS` includes it only
+when the server has a TURN relay configured, because a client reads `COMPFLAGS` to decide
+whether to offer relay hosting at all. It stays in `flag_map` on every server, so a client
+that sends `r` to a server with no relay is never told the flag is unknown: it just gets
+`TURNCREDENTIALSFAILED` if it asks for a credential. See
+[Relay hosting](#71-relay-hosting-turncredentials).
+
 Deprecated/removed flags still recognised for negotiation: `cl`, `t`, `l`, `a`, `m`,
 `p`, `et` — these represent behaviour that is now mandatory or was removed. **[GAP]**
 document `LISTCOMPFLAGS` output and exactly how/when a client declares its flags during
@@ -171,7 +178,7 @@ connection holds the listed level (higher levels inherit lower ones in practice 
 | **user — channel** | `CHANNELS`, `CHANNELTOPIC`, `JOIN`, `LEAVE`, `SAY`, `SAYEX`, `SAYPRIVATE`, `SAYPRIVATEEX`, `GETCHANNELMESSAGES` |
 | **user — account** | `GETUSERINFO`, `RENAMEACCOUNT`, `CHANGEPASSWORD`, `CHANGEEMAILREQUEST`, `CHANGEEMAIL`, `RESENDVERIFICATION` |
 | **user — social** | `IGNORE`, `UNIGNORE`, `IGNORELIST`, `FRIENDREQUEST`, `ACCEPTFRIENDREQUEST`, `DECLINEFRIENDREQUEST`, `UNFRIEND`, `FRIENDLIST`, `FRIENDREQUESTLIST` |
-| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON` |
+| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON`, `TURNCREDENTIALS` |
 | **user — bridge** | `BRIDGECLIENTFROM`, `UNBRIDGECLIENTFROM`, `JOINFROM`, `LEAVEFROM`, `SAYFROM` |
 | **user — deprecated** | `MUTE`, `MUTELIST`, `SETCHANNELKEY`, `UNMUTE`, `SAYBATTLE`, `SAYBATTLEEX`, `SAYBATTLEPRIVATEEX`, `FORCELEAVECHANNEL`, `GETINGAMETIME` |
 | **mod** | `GETUSERID`, `GETIP`, `FINDIP`, `SETBOTMODE`, `CREATEBOTACCOUNT`, `RESETUSERPASSWORD`, `KICK`, `BAN`, `BANSPECIFIC`, `UNBAN`, `BLACKLIST`, `UNBLACKLIST`, `LISTBANS`, `LISTBLACKLIST` |
@@ -272,6 +279,50 @@ bots, script_tags, startrects, map/mod/engine, player/spectator limits.
   `DISABLEUNITS` / `ENABLEUNITS` / `ENABLEALLUNITS`.
 - Host force-commands: `FORCEALLYNO`, `FORCETEAMNO`, `FORCETEAMCOLOR`,
   `FORCESPECTATORMODE`, `HANDICAP`, `KICKFROMBATTLE`, `RING`.
+
+### 7.1 Relay hosting (`TURNCREDENTIALS`)
+
+A player who cannot forward a port can host through a TURN relay instead. The relay
+allocation is an ordinary public address, so the battle is advertised in `BATTLEOPENED` and
+joined like any other direct host. The lobby's only job is to vouch for its own users, which
+it does by minting a credential the relay will accept.
+
+```
+C> TURNCREDENTIALS
+S> TURNCREDENTIALS <uri> <username> <password> <ttl_seconds>
+S> TURNCREDENTIALSFAILED <reason>
+```
+
+Requires login. The success reply is exactly four space-separated fields and none of `uri`,
+`username` or `password` may be empty or contain a space, because a space in any of them
+shifts every field after it. `ttl_seconds` is a plain base-10 integer and comes last, so a
+client can use it to detect a shifted line. The failure reason is the rest of the line and
+may contain spaces. It is free text meant to be shown to a person.
+
+The credential is `draft-uberti-behave-turn-rest-00`, which coturn implements as
+`use-auth-secret`:
+
+```
+username = "<unix expiry timestamp>:<lobby account id>"
+password = base64(hmac_sha1(shared secret, username))
+```
+
+The relay recomputes the HMAC from a `static-auth-secret` it shares with the lobby, so the
+two processes never talk and neither holds session state. The secret is server configuration
+(`server_turn.txt`, see the README) and is never sent to a client.
+
+`ttl_seconds` is how long the credential stays valid, 43200 (12 hours) by default and set by
+the operator. It is sized against a whole game rather than battle setup: coturn re-checks the
+expiry on every refresh of a live allocation, and the relay outlives the lobby connection, so
+a credential that expires part way through ends the game rather than merely blocking new
+allocations.
+
+Failure cases, all reported as `TURNCREDENTIALSFAILED <reason>`:
+- the server has no relay configured, in which case `r` is also absent from `COMPFLAGS`
+- the caller has asked too often, limited to 3 credentials decaying by one every 20 minutes,
+  matching the `REGISTER` and `RENAMEACCOUNT` limits
+- the server could not build a credential whose fields are free of spaces, which means its
+  TURN URI is misconfigured
 
 ---
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -312,10 +312,13 @@ two processes never talk and neither holds session state. The secret is server c
 (`server_turn.txt`, see the README) and is never sent to a client.
 
 `ttl_seconds` is how long the credential stays valid, 43200 (12 hours) by default and set by
-the operator. It is sized against a whole game rather than battle setup: coturn re-checks the
-expiry on every refresh of a live allocation, and the relay outlives the lobby connection, so
-a credential that expires part way through ends the game rather than merely blocking new
-allocations.
+the operator. It is sized against a whole game rather than battle setup. coturn judges the
+credential when it creates the session and checks later requests against the key it kept, so
+an expiry passing under a live allocation costs nothing. What costs a game is expiry before
+the relay has to be rebuilt, because a rebuild opens a new session and a dead credential is
+refused. The relay outlives the lobby connection, so nothing can mint a replacement at that
+point. The server warns at startup if the configured lifetime is below what clients accept,
+which the README's `server_turn.txt` section sources and explains.
 
 Failure cases, all reported as `TURNCREDENTIALSFAILED <reason>`:
 - the server has no relay configured, in which case `r` is also absent from `COMPFLAGS`

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -178,7 +178,7 @@ connection holds the listed level (higher levels inherit lower ones in practice 
 | **user — channel** | `CHANNELS`, `CHANNELTOPIC`, `JOIN`, `LEAVE`, `SAY`, `SAYEX`, `SAYPRIVATE`, `SAYPRIVATEEX`, `GETCHANNELMESSAGES` |
 | **user — account** | `GETUSERINFO`, `RENAMEACCOUNT`, `CHANGEPASSWORD`, `CHANGEEMAILREQUEST`, `CHANGEEMAIL`, `RESENDVERIFICATION` |
 | **user — social** | `IGNORE`, `UNIGNORE`, `IGNORELIST`, `FRIENDREQUEST`, `ACCEPTFRIENDREQUEST`, `DECLINEFRIENDREQUEST`, `UNFRIEND`, `FRIENDLIST`, `FRIENDREQUESTLIST` |
-| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON`, `TURNCREDENTIALS`, `RELAYEDHOST` |
+| **user — meta** | `MYSTATUS`, `PORTTEST`, `JSON`, `TURNCREDENTIALS`, `RELAYEDHOST`, `MOVERELAYEDHOST` |
 | **user — bridge** | `BRIDGECLIENTFROM`, `UNBRIDGECLIENTFROM`, `JOINFROM`, `LEAVEFROM`, `SAYFROM` |
 | **user — deprecated** | `MUTE`, `MUTELIST`, `SETCHANNELKEY`, `UNMUTE`, `SAYBATTLE`, `SAYBATTLEEX`, `SAYBATTLEPRIVATEEX`, `FORCELEAVECHANNEL`, `GETINGAMETIME` |
 | **mod** | `GETUSERID`, `GETIP`, `FINDIP`, `SETBOTMODE`, `CREATEBOTACCOUNT`, `RESETUSERPASSWORD`, `KICK`, `BAN`, `BANSPECIFIC`, `UNBAN`, `BLACKLIST`, `UNBLACKLIST`, `LISTBANS`, `LISTBLACKLIST` |
@@ -280,7 +280,7 @@ bots, script_tags, startrects, map/mod/engine, player/spectator limits.
 - Host force-commands: `FORCEALLYNO`, `FORCETEAMNO`, `FORCETEAMCOLOR`,
   `FORCESPECTATORMODE`, `HANDICAP`, `KICKFROMBATTLE`, `RING`.
 
-### 7.1 Relay hosting (`TURNCREDENTIALS`, `CLIENTIP`, `RELAYEDHOST`)
+### 7.1 Relay hosting (`TURNCREDENTIALS`, `CLIENTIP`, `RELAYEDHOST`, `MOVERELAYEDHOST`)
 
 A player who cannot forward a port can host through a TURN relay instead. The relay
 allocation is an ordinary public address, so the battle is advertised in `BATTLEOPENED` and
@@ -389,10 +389,9 @@ exactly as it dials a direct one. There is nothing here for SpringLobby or Chobb
 and inventing a NAT mode would have cost every one of them a change.
 
 The `<port>` is in this line as well as in `OPENBATTLE`. `OPENBATTLE` is the one the battle is
-advertised at. This one is here because a rebuilt allocation moves the address and the port
-together, and saying so without reopening the battle needs both in one line. Updating a battle
-that is already open is not implemented, so today the server range-checks this port and then
-discards it. Send the real one anyway, because an out-of-range value is refused.
+advertised at, so the server range-checks this one and then discards it. Send the real one
+anyway, because an out-of-range value is refused. `MOVERELAYEDHOST` is the command whose port
+is used, because it has no `OPENBATTLE` behind it to carry one.
 
 All three of the address translations `BATTLEOPENED` normally does are skipped, including the
 one that hands a joiner the host's LAN address when the two share a WAN address. Two players
@@ -416,6 +415,88 @@ differ from the address it signals on, and resolving a name inside the command h
 stall the reactor.
 
 A client that sends no `RELAYEDHOST` sees a byte-for-byte unchanged battle.
+
+#### Moving an open battle (`MOVERELAYEDHOST`)
+
+A TURN allocation can be lost, and the replacement the host builds is on a different address
+and a different port. The battle is still open and the room is still full, but it is advertised
+at a pair nobody can reach. `MOVERELAYEDHOST` moves it without closing it, so the room and
+everybody in it stay where they are.
+
+```
+C> MOVERELAYEDHOST <ip> <port>
+S> BATTLEHOSTMOVED <battle_id> <ip> <port>
+S> MOVERELAYEDHOSTFAILED <reason>
+```
+
+Requires login, the `r` flag, and that the sender is the host of an open battle that was
+opened through a relay. Two plain fields, no tab sentence, and `<ip>` may be IPv4 or IPv6, as
+in `RELAYEDHOST`. There is no separate success reply: the host receives the same
+`BATTLEHOSTMOVED` everybody else does.
+
+This port is used, unlike `RELAYEDHOST`'s. There is no `OPENBATTLE` behind this line to carry
+one, and a rebuilt allocation moves the address and the port together, so a move that changed
+only the address would put the battle on the right machine at the wrong port and leave it
+exactly as unreachable as it was. From here on the battle is advertised at this pair, and the
+three address translations `BATTLEOPENED` normally does stay skipped.
+
+`natType` is untouched and stays `0`, for the reason it is `0` at `OPENBATTLE`: a TURN
+allocation is an ordinary public UDP address and a joining client needs to understand nothing
+about it.
+
+This is a separate command rather than a second `RELAYEDHOST` because "the sender is already
+hosting" does not tell the two cases apart. A relay host reopening its battle sends
+`RELAYEDHOST` while the old battle is still open, and the server reads that staged address
+before the `LEAVEBATTLE` which closes the old battle. One command would read that line as a
+move, apply it to a battle about to be destroyed, and advertise the new battle at the host's
+own unreachable machine.
+
+**What other clients see.** `BATTLEHOSTMOVED` goes to every logged-in client that sent `r` at
+login, including the host, and to nobody else. Anyone who joins or logs in after a move reads
+the new pair out of the ordinary `BATTLEOPENED` they are sent for the battle, so the message
+only has to reach clients that are already holding the old pair.
+
+A client that did not send `r` keeps the old address and port until it disconnects and receives
+the battle afresh. That is a stale list entry rather than a break, and it applies to people
+sitting in the room as much as to people looking at the list. There is nothing better available
+in this protocol:
+
+- no message changes a battle's address after `BATTLEOPENED`. `UPDATEBATTLEINFO` carries the
+  spectator count, the lock, the map and its hash, and no address
+- re-sending `BATTLEOPENED` for the same battle id does not work. SpringLobby asserts that the
+  battle does not already exist, throws, and logs a warning, so the line is dropped. Chobby
+  rebuilds its record of the battle from the new line and loses the user list with it
+- `HOSTPORT` is the closest existing message and still does not fit. It carries a port and no
+  address, and SpringLobby ignores it unless the battle's `natType` is one of the NAT-traversal
+  modes, which a relayed battle's never is
+- `BATTLECLOSED` followed by `BATTLEOPENED` would refresh the list for onlookers, at the price
+  of telling every bot, bridge and autohost on the server that a live battle closed, and firing
+  SpringLobby's "opened battle" notification on every relay rebuild. It cannot help the people
+  in the room either, because a client told that its own battle closed leaves it
+
+For the case this exists for, a stale entry costs that client nothing it had: the address it is
+still holding had already stopped working. A client that wants the correct one asks for `r` at
+login.
+
+**Battles that were never relayed are not moved.** A battle opened without a `RELAYEDHOST` is
+advertised at an address that works, and everyone holding it would be stranded there by a move
+nothing can tell them about. Converting it would break a working battle rather than repair a
+broken one, so a battle's addressing scheme is fixed for its lifetime.
+
+Failure cases, all reported as `MOVERELAYEDHOSTFAILED <reason>`, free text meant to be shown to
+whoever is trying to host:
+- the server has no relay configured, in which case `r` is also absent from `COMPFLAGS`
+- the client did not send `r` at login
+- the sender is not in a battle
+- the sender is in a battle but is not its host. A spectator must not be able to send everybody
+  in somebody else's battle to an address of its choosing
+- the battle was not opened through a relay
+- the address does not parse as an IP address at all
+- the address is not a public one, by the same check `RELAYEDHOST` applies
+- the port is not a whole number between 1 and 65535
+
+A refused move changes nothing and announces nothing, and a client that never sends
+`MOVERELAYEDHOST` sees a byte-for-byte unchanged battle.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ a_long_random_string
 
 The TURN server can run anywhere, on this machine or another host. It needs `use-auth-secret` turned on and a `static-auth-secret` set to the same string as line 2. coturn then recomputes each credential itself, so it never talks to the lobby and keeps no session state. Use `turns:` on port 5349 if your relay serves TLS.
 
-This file is only the lobby's half. Running the relay itself, what it costs to run, and how to check it works are in [Relay Hosting (TURN)](#relay-hosting-turn).
+This file is only the lobby's half. Running the relay itself, what it costs to run, and how to check it works are in [Relay Hosting (TURN)](#relay-hosting-turn). If you are turning relay hosting on for the first time, follow [docs/ops/relay-hosting-setup.md](docs/ops/relay-hosting-setup.md), which puts the whole job in order.
 
 Line 3 is the number of seconds a credential stays valid. coturn judges the credential once, when it creates the session, and checks later requests against the key it kept, so an expiry passing under a live allocation costs nothing. What cuts a game off is expiry before the relay has to be rebuilt, because a rebuild opens a new session, the credential is judged again, and a dead one is refused. The default of 43200 (12 hours) is sized to outlast a long game, because the relay agent keeps running after the lobby connection has gone and nothing can ask for a replacement.
 
@@ -654,6 +654,8 @@ Note that `local_ip` is supplied by the client in its `LOGIN` command and is onl
 A player who cannot forward a port cannot host a battle. Relay hosting gives them a way round it: they open an allocation on a TURN relay, the battle is advertised at the relay's address, and everyone else joins it exactly as they would join any other host. It is optional. Without it those players can still play, they just cannot host.
 
 There are two halves. The lobby half is [`server_turn.txt`](#server_turntxt---relay-hosting-turn) above, three lines of config. The relay half is a coturn server, and that is what this section is about. You have to run it, and every byte it carries is on your bill.
+
+This section is reference material, organised by topic. Doing it for the first time, work through [docs/ops/relay-hosting-setup.md](docs/ops/relay-hosting-setup.md) instead, which is the same job in the order it has to happen and links back here for the reasoning at each decision.
 
 ### The lobby does not care where the relay runs
 

--- a/README.md
+++ b/README.md
@@ -479,7 +479,9 @@ The TURN server can run anywhere, on this machine or another host. It needs `use
 
 This file is only the lobby's half. Running the relay itself, what it costs to run, and how to check it works are in [Relay Hosting (TURN)](#relay-hosting-turn).
 
-Line 3 is the number of seconds a credential stays valid. coturn re-checks the expiry every time the relay refreshes an allocation, so a credential that runs out mid-game cuts that game off. The default of 43200 (12 hours) is sized to outlast a long game, because the relay agent keeps running after the lobby connection has gone and nothing can ask for a replacement.
+Line 3 is the number of seconds a credential stays valid. coturn judges the credential once, when it creates the session, and checks later requests against the key it kept, so an expiry passing under a live allocation costs nothing. What cuts a game off is expiry before the relay has to be rebuilt, because a rebuild opens a new session, the credential is judged again, and a dead one is refused. The default of 43200 (12 hours) is sized to outlast a long game, because the relay agent keeps running after the lobby connection has gone and nothing can ask for a replacement.
+
+Do not set line 3 below 5115 seconds. Coilbox refuses to open a relayed battle on a credential shorter than that and says so before anybody joins, and the server logs a warning at startup if you configure one. The figure is 5083 seconds, the 99th percentile of 18418 real games from api.bar-rts.com covering 22 to 29 August 2026, plus the relay agent's 32 second worst-case rebuild backoff. Median over those games was 1302s and p90 3051s, so the floor sits well clear of ordinary play. The derivation is tomjn/coilbox#2091, and the coturn behaviour it rests on was measured against 4.17.2 in tomjn/coilbox#2041. Other clients may accept less, which is why a lifetime under the floor is a warning rather than a refusal.
 
 Treat the secret like a password: anyone who has it can mint credentials for your relay. The server never logs it and never sends it to a client.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ sudo ufw allow 8201/udp
 
 > If you're on a cloud VPS (AWS, Hetzner, DigitalOcean etc.), also open these ports in your cloud provider's firewall or security group.
 
+Running a TURN relay for relay hosting needs more ports than these, including a range. Those are listed separately under [Relay Hosting (TURN)](#relay-hosting-turn), and you only need them if you turn that feature on.
+
 ---
 
 ## 6. Create an Admin User
@@ -475,6 +477,8 @@ a_long_random_string
 
 The TURN server can run anywhere, on this machine or another host. It needs `use-auth-secret` turned on and a `static-auth-secret` set to the same string as line 2. coturn then recomputes each credential itself, so it never talks to the lobby and keeps no session state. Use `turns:` on port 5349 if your relay serves TLS.
 
+This file is only the lobby's half. Running the relay itself, what it costs to run, and how to check it works are in [Relay Hosting (TURN)](#relay-hosting-turn).
+
 Line 3 is the number of seconds a credential stays valid. coturn re-checks the expiry every time the relay refreshes an allocation, so a credential that runs out mid-game cuts that game off. The default of 43200 (12 hours) is sized to outlast a long game, because the relay agent keeps running after the lobby connection has gone and nothing can ask for a replacement.
 
 Treat the secret like a password: anyone who has it can mint credentials for your relay. The server never logs it and never sends it to a client.
@@ -643,6 +647,181 @@ Note that `local_ip` is supplied by the client in its `LOGIN` command and is onl
 
 ---
 
+## Relay Hosting (TURN)
+
+A player who cannot forward a port cannot host a battle. Relay hosting gives them a way round it: they open an allocation on a TURN relay, the battle is advertised at the relay's address, and everyone else joins it exactly as they would join any other host. It is optional. Without it those players can still play, they just cannot host.
+
+There are two halves. The lobby half is [`server_turn.txt`](#server_turntxt---relay-hosting-turn) above, three lines of config. The relay half is a coturn server, and that is what this section is about. You have to run it, and every byte it carries is on your bill.
+
+### The lobby does not care where the relay runs
+
+The lobby never connects to the relay. It mints a credential as an HMAC of a shared secret, and coturn recomputes the same HMAC from its own copy of that secret. Neither process holds state about the other and neither has to be able to reach the other.
+
+That means the relay can be a container alongside the lobby, a second machine in the same rack, or a machine on another continent, and the lobby's configuration is the same three lines in every case. Moving it later is one edit to line 1 of `server_turn.txt` and a lobby restart.
+
+The one thing that has to match is the secret. `static-auth-secret` in the coturn config and line 2 of `server_turn.txt` must be the same string, byte for byte. **Nothing detects a mismatch.** coturn refuses every credential it is handed, every relayed battle fails to start, and the lobby has no idea. Change one, change the other.
+
+### Same machine, or its own?
+
+| | On the lobby machine | On its own host |
+|---|---|---|
+| Cost | One machine, one bill | A second machine, and the relay's bandwidth bill is usually the larger of the two |
+| Relay traffic starving the lobby | Possible. `bps-capacity` is the only thing stopping it | Cannot happen |
+| Taking the machine down | Ends every relayed game in progress | Relayed games carry on |
+| Where you can put it | Wherever the lobby already is | Wherever the players are |
+
+The third row is the one worth thinking about. A relayed battle outlives the lobby connection that started it: the credential is minted once, sized to outlast a whole game, and nothing ever asks for a replacement. Under Compose, `docker compose restart uberserver` leaves the relay alone, but a reboot or a `docker compose down` does not, and on a shared machine that ends games which had nothing to do with the lobby.
+
+Sharing is cheaper and there is nothing wrong with starting there. Splitting is the upgrade, and because the lobby side does not change, it is an upgrade you can make later.
+
+### Where you put it decides the latency players pay
+
+A relayed battle goes host to relay to player, instead of host to player. Every packet pays the trip to the relay and back out again, both ways. A relay close to the players is worth more than a fast one far from them, so put it near the community rather than near yourself.
+
+If the relay is on the lobby machine, you do not get this choice: it lives wherever the lobby lives.
+
+### What it costs
+
+The engine bounds how much a host sends. `LinkOutgoingBandwidth` defaults to 64 KiB per user per second (`rts/System/GlobalConfig.cpp:36-38` in the engine, quoted in [issue #29](https://github.com/ScarylePoo/uberserver/issues/29)). Nothing in this repository has checked the engine source, so treat that figure as coming from the issue rather than from here.
+
+Relayed traffic crosses the relay twice, once in from the host and once out to the player, and that doubling is the whole point of the sum. For the host's outgoing stream at that ceiling:
+
+| Players | Host sends | Relay carries, each direction | Per battle-hour, each direction |
+|---|---|---|---|
+| 8 | 524288 B/s (4.19 Mbit/s) | 524288 B/s | 1.76 GiB |
+| 16 | 1048576 B/s (8.39 Mbit/s) | 1048576 B/s | 3.52 GiB |
+| 32 | 2097152 B/s (16.78 Mbit/s) | 2097152 B/s | 7.03 GiB |
+
+Redo it with your own player count: `players x 65536` bytes per second, in each direction, and multiply by 3600 for an hour. Most hosts bill outbound only, so the last column is the one to price against.
+
+Two things that sum leaves out. Traffic the other way, player to host, crosses the relay too, and there is no sourced figure here for what a client sends, so the real total is higher than the table. And this is a ceiling rather than a measurement: a real battle uses less, often much less.
+
+### Setting it up with Docker Compose
+
+The relay is behind a Compose profile, so it does not start unless you ask for it.
+
+```bash
+cp turnserver.conf.example turnserver.conf
+nano turnserver.conf
+docker compose --profile relay up -d
+```
+
+Copy the file before you bring the service up. Docker creates a directory where a missing bind mount source should be, and coturn then starts with no configuration at all.
+
+`turnserver.conf.example` is commented throughout and every value in it that is a deployment choice is tagged `EXAMPLE`. Work yours out from the sections below rather than shipping the numbers as they stand.
+
+Generate the secret, and put the same string on line 2 of `server_turn.txt`:
+
+```bash
+openssl rand -hex 32
+```
+
+The service uses host networking, because coturn hands out one UDP port per allocation from its `min-port`..`max-port` range and Docker expands a published port range into one forwarding rule per port. If host networking is not available to you, the alternative is written into the comments in `docker-compose.yml`: narrow the range and publish it.
+
+### Setting it up on its own host
+
+Nothing in this repository needs to be on that machine. Copy `turnserver.conf.example` across, edit it, and run coturn however you prefer. The same image, without Compose:
+
+```bash
+docker run -d --name coturn --restart unless-stopped --network host \
+  -v /etc/coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro \
+  coturn/coturn:4.17.2 -c /etc/coturn/turnserver.conf
+```
+
+Or your distribution's own `coturn` package, with the config wherever its service unit looks for it. The settings in the example config were checked against coturn 4.17.2. Run `turnserver --version` and read coturn's own release notes if yours is older.
+
+Then put that machine's hostname in line 1 of `server_turn.txt` on the lobby and restart the lobby. That address has to be a public one: the server refuses to advertise a battle at anything private, and a relay nobody outside can reach is no use anyway.
+
+### Ports and firewall
+
+```bash
+sudo ufw allow 3478/udp
+sudo ufw allow 3478/tcp
+sudo ufw allow 49152:49401/udp   # must match min-port..max-port in turnserver.conf
+```
+
+And, only if you enable TLS:
+
+```bash
+sudo ufw allow 5349/tcp
+sudo ufw allow 5349/udp
+```
+
+> If you're on a cloud VPS (AWS, Hetzner, DigitalOcean etc.), also open these in your cloud provider's firewall or security group.
+
+Say this out loud before you run it: the third line opens a **range**. That is a far bigger hole than the single `8201/udp` the lobby already has open. The example config uses 250 ports. coturn's own default range is `49152`-`65535`, which is 16384 of them, and nothing forces you to take the default. Size the range to the number of concurrent relayed battles you actually want to support, one port each, and open only that.
+
+### Quotas are the only thing between this and free transit
+
+coturn's `user-quota`, `total-quota`, `max-bps` and `bps-capacity` all default to `0`, meaning unlimited (coturn's shipped `turnserver.conf.default`). Left at the defaults, anyone who can register on your lobby can push whatever they like through your relay, to wherever they like, as fast as your link goes. A game is not the only thing that fits down a UDP relay.
+
+There is no correct value for any of them. What there is, is arithmetic:
+
+- **`user-quota`** is concurrent allocations per lobby account. A relayed battle needs one. Leave a little headroom above that: a host whose allocation is refused after a coturn restart builds a new one, and the old one may not have expired yet.
+- **`total-quota`** is concurrent allocations across the server. Keep it at or below the size of your port range, so you run out of quota rather than out of ports.
+- **`max-bps`** is bytes per second per allocation, each direction counted separately. Set it to at least `max players x 65536` from the table above. Set it lower and you silently drop game traffic, which players report as lag rather than as a broken relay.
+- **`bps-capacity`** is bytes per second across the whole server, each direction counted separately. This is the one that stops the relay starving everything else on the machine, and the one that caps your bandwidth bill. Size it from the link you are paying for.
+
+The example config also denies the private address ranges as relay peers. On a shared machine, an unrestricted relay will happily forward to the lobby, the database, and anything else on the private network.
+
+### TLS on 5349
+
+Plain TURN is UDP to port 3478, and some networks will not pass that. TURNS over TLS on 5349 looks like ordinary TLS traffic and gets through more of them, so it is worth having for the players who need it.
+
+It needs a certificate from a CA the players' clients already trust, with a name matching the host in line 1 of `server_turn.txt`. The lobby's self-signed `server.pem` will not do, because a client that checks the chain refuses it. `tls-listening-port`, `cert` and `pkey` are commented out together in the example config. Uncomment all three or none, because coturn logs an error and does not listen if the port is set without a usable certificate.
+
+coturn reads the certificate once, at startup. `SIGHUP` only reopens its log file (`man turnserver`), so renewing means restarting.
+
+### Restarting the relay
+
+A restart is survivable. Per the [findings posted on issue #29](https://github.com/ScarylePoo/uberserver/issues/29) from a client run against coturn 4.17.2, a restarted coturn answers `437` to a refresh for an allocation it has forgotten, and the client responds by building a new allocation and carrying on. A drain answers `403` and is handled the same way.
+
+The catch is the credential. Rebuilding needs the host's credential to still be valid at that moment, and nothing can hand out a replacement once the lobby connection has gone. That is what line 3 of `server_turn.txt` is for, and why its default is 12 hours rather than something tidier.
+
+### Checking it works
+
+coturn ships its own test clients. Run these from somewhere outside your network, not from the relay itself, or you will only prove the firewall is open to yourself.
+
+**Is the relay reachable at all?**
+
+```bash
+turnutils_stunclient -p 3478 relay.example.org
+```
+
+Expect one line naming the address it saw you at, like `IPv4. UDP reflexive addr: 203.0.113.5:63944`. Nothing back means the port is closed or coturn is not running.
+
+**Does a credential work?**
+
+Mint one the same way the lobby does, from line 2 of `server_turn.txt`, and use it to open an allocation. You need an echo peer with a public address for the last part: run `turnutils_peer -p 3480` on some other machine and point `-e` at it.
+
+```bash
+secret=$(sed -n 2p server_turn.txt)
+turnuser="$(( $(date +%s) + 3600 )):1"
+turnpass=$(printf %s "$turnuser" | openssl dgst -sha1 -hmac "$secret" -binary | base64)
+turnutils_uclient -u "$turnuser" -w "$turnpass" -p 3478 -e 203.0.113.9 -r 3480 -n 3 relay.example.org
+```
+
+Expect it to finish with `Total lost packets 0`. That is the whole path working: credential accepted, allocation opened, permission installed, packets relayed both ways.
+
+### Telling the relay, the credential and the firewall apart
+
+| What you see | Where the problem is |
+|---|---|
+| `turnutils_stunclient` gets nothing back | Firewall or coturn. Port 3478 is closed, or the process is not running |
+| `turnutils_stunclient` answers, `turnutils_uclient` says `Cannot complete Allocation`, and coturn logs `check_stun_auth: Cannot find credentials of user <...>` | The credential. `static-auth-secret` and line 2 of `server_turn.txt` are different strings |
+| Allocation succeeds but no packets come back | The allocation port range. It is open to the relay, but not through the firewall in front of it |
+| Everything above passes and battles still fail | Not the relay. Check the lobby advertises `r` in `COMPFLAGS`, which needs `server_turn.txt` to have loaded |
+
+The middle row is the common one, and it is worth knowing that the coturn log line names the username the lobby minted, `<expiry>:<account id>`. If that line is absent entirely, the request never reached coturn and it is the row above.
+
+Follow the relay's own log while you test:
+
+```bash
+docker compose logs -f coturn
+```
+
+---
+
 ## Troubleshooting
 
 **Container keeps restarting**
@@ -659,6 +838,11 @@ docker compose exec uberserver cat /app/server.log
 - Check the advertised address: PM ChanServ `:showip`
 - If it's stale, PM ChanServ `:refreship` (admin) or `docker compose restart uberserver`
 - Full explanation: [Host IP Detection](#host-ip-detection)
+
+**Relayed battles fail to start**
+- Check the lobby loaded its config: `docker compose logs uberserver | grep -i "relay hosting"`
+- Check the relay is running: `docker compose logs -f coturn`
+- Work out which of the three parts is broken: [Telling the relay, the credential and the firewall apart](#telling-the-relay-the-credential-and-the-firewall-apart)
 
 **Need to wipe and start fresh** (deletes all data)
 ```bash

--- a/README.md
+++ b/README.md
@@ -455,6 +455,34 @@ Get a free API key at https://iphub.info — the free tier allows 1,000 checks p
 
 ---
 
+### server_turn.txt - Relay Hosting (TURN)
+
+Lets a player who cannot forward a port host a battle through a TURN relay. When this file is present the server advertises the `r` compatibility flag and answers the `TURNCREDENTIALS` command with a credential the relay will accept.
+
+```
+line 1: TURN URI              (required)
+line 2: shared secret         (required)
+line 3: credential lifetime   (optional, seconds, default 43200)
+```
+
+**Example:**
+
+```
+turn:relay.example.org:3478
+a_long_random_string
+43200
+```
+
+The TURN server can run anywhere, on this machine or another host. It needs `use-auth-secret` turned on and a `static-auth-secret` set to the same string as line 2. coturn then recomputes each credential itself, so it never talks to the lobby and keeps no session state. Use `turns:` on port 5349 if your relay serves TLS.
+
+Line 3 is the number of seconds a credential stays valid. coturn re-checks the expiry every time the relay refreshes an allocation, so a credential that runs out mid-game cuts that game off. The default of 43200 (12 hours) is sized to outlast a long game, because the relay agent keeps running after the lobby connection has gone and nothing can ask for a replacement.
+
+Treat the secret like a password: anyone who has it can mint credentials for your relay. The server never logs it and never sends it to a client.
+
+> If this file is not present, relay hosting is disabled, `r` is left out of `COMPFLAGS`, and `TURNCREDENTIALS` replies `TURNCREDENTIALSFAILED`.
+
+---
+
 ### bad_words.txt — Profanity Filter
 
 A list of words to censor in chat. One word per line. The server replaces matched words with `***` in channels where censoring is enabled.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,46 @@ services:
         soft: 65536
         hard: 65536
 
+  # Optional TURN relay, for players who cannot forward a port and host through
+  # a relay instead. Opt-in: nothing here starts unless you ask for the profile.
+  #
+  #   cp turnserver.conf.example turnserver.conf   # then edit it
+  #   docker compose --profile relay up -d
+  #
+  # Copy the config first. Docker creates a directory in place of a missing bind
+  # mount source, and coturn then starts with no configuration at all.
+  #
+  # The relay does not talk to the lobby and is not on the internal network. The
+  # only thing tying the two together is the shared secret, which has to be the
+  # same string here and on line 2 of server_turn.txt. See the README, under
+  # "Relay Hosting (TURN)", including the case for running this somewhere else
+  # entirely rather than on the lobby machine.
+  coturn:
+    profiles:
+      - relay
+    image: coturn/coturn:4.17.2
+    restart: unless-stopped
+    command: ["-c", "/etc/coturn/turnserver.conf"]
+    # Host networking, because coturn hands out one UDP port per allocation from
+    # the min-port..max-port range in its config, and Docker expands a published
+    # port range into one forwarding rule per port. Publishing coturn's default
+    # 16384 port range that way is not something to do casually.
+    #
+    # If host networking is not available to you, drop this line, narrow
+    # min-port/max-port to something you have sized, and publish that range:
+    #   ports:
+    #     - "3478:3478/udp"
+    #     - "3478:3478/tcp"
+    #     - "49152-49401:49152-49401/udp"
+    network_mode: host
+    volumes:
+      - ./turnserver.conf:/etc/coturn/turnserver.conf:ro
+      # TLS on 5349. Uncomment these with the tls-listening-port, cert and pkey
+      # lines in turnserver.conf, and point them at a certificate the players'
+      # clients trust. Never commit the key.
+      # - ./turn_cert.pem:/etc/coturn/turn_cert.pem:ro
+      # - ./turn_pkey.pem:/etc/coturn/turn_pkey.pem:ro
+
 volumes:
   db_data:
   server_logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,9 @@ services:
       # Optional: mount custom motd / agreement files
       # - ./server_motd.txt:/app/server_motd.txt:ro
       # - ./server_agreement.txt:/app/server_agreement.txt:ro
+      # Relay hosting. The lobby reads this from its working directory, so it has
+      # to be mounted to reach the container. See docs/ops/relay-hosting-setup.md
+      # - ./server_turn.txt:/app/server_turn.txt:ro
     networks:
       - internal
     sysctls:

--- a/docs/ops/relay-hosting-setup.md
+++ b/docs/ops/relay-hosting-setup.md
@@ -1,0 +1,238 @@
+# Relay hosting setup runbook
+
+Takes you from a working lobby to relay hosting you have checked works, in the order the steps have to happen in.
+
+Everything here is a sequence. The reasoning behind each choice lives in the README's [Relay Hosting (TURN)](../../README.md#relay-hosting-turn) section, which is organised by topic rather than by order, and this runbook links into it rather than repeating it. If you want to know why a decision goes the way it does, follow the link.
+
+Two things about the order, because they are the reason this document exists:
+
+- The relay gets built and proved before the lobby is told about it. The moment `server_turn.txt` exists and the lobby restarts, the lobby starts telling clients it offers relay hosting, and players will try to use it. Prove the relay first and nobody ever meets a broken one.
+- The shared secret is generated once, in step 4, and typed nowhere. Every later step copies that same string. Nothing on either side detects a mismatch, so a second `openssl rand` run is the most expensive mistake available here.
+
+Before you start you need a lobby you can restart, a machine to run coturn on, and root on whatever runs the firewall.
+
+The expected output quoted in this runbook came from running the commands against coturn 4.17.2 and a lobby from this repository over loopback. Yours will name your own addresses.
+
+## Decisions, before anything is installed
+
+### 1. Decide where the relay runs
+
+Two options. On the lobby machine, or on its own host. The table in [Same machine, or its own?](../../README.md#same-machine-or-its-own) has the tradeoff. The short version is that sharing is cheaper and fine to start with, and splitting later costs one line of lobby config, which is step 12.
+
+If you are choosing between locations for a separate host, put it near the players rather than near yourself. [Where you put it decides the latency players pay](../../README.md#where-you-put-it-decides-the-latency-players-pay).
+
+Check: you can name the machine, and you have a shell on it.
+
+### 2. Decide the address players will reach it at
+
+The relay needs one public address, and that address goes in two places later: coturn's `external-ip` if the machine is behind NAT, and line 1 of the lobby's `server_turn.txt`. A hostname is easier to move than a bare IP.
+
+The lobby refuses to advertise a battle at a private address, and a relay nobody outside can reach is no use anyway.
+
+```bash
+dig +short relay.example.org
+```
+
+Check: the name resolves to the public address you expect. If the machine is behind NAT, note both addresses now, because coturn needs the pair.
+
+### 3. Size it
+
+Decide how many concurrent relayed battles you want to support and how large a battle is. Everything else falls out of those two numbers:
+
+- The allocation port range is one UDP port per concurrent relayed battle. That sets `min-port` and `max-port`, and it is also the size of the hole you will open in the firewall.
+- `max-bps` comes from the players per battle. The arithmetic is in [What it costs](../../README.md#what-it-costs), along with what it means for your bandwidth bill.
+- `user-quota`, `total-quota` and `bps-capacity` come from the same two numbers. [Quotas are the only thing between this and free transit](../../README.md#quotas-are-the-only-thing-between-this-and-free-transit) explains why leaving them at coturn's unlimited defaults turns your relay into free transit for anyone with an account on your lobby.
+
+Check: you have written down six numbers, `min-port`, `max-port`, `user-quota`, `total-quota`, `max-bps` and `bps-capacity`, and you can say where each came from.
+
+## Build the relay
+
+### 4. Generate the shared secret, once
+
+```bash
+openssl rand -hex 32
+```
+
+Keep that string somewhere you can copy it exactly. It goes into `turnserver.conf` in step 5 and into `server_turn.txt` in step 9, and those two copies have to be the same string.
+
+Nothing detects a mismatch. coturn answers 401 to every credential the lobby minted, every relayed battle fails to start, and the lobby never finds out because it never talks to the relay. Step 9 has the check that catches it, and it is the only check anywhere that will.
+
+Leading and trailing whitespace is safe on both sides. The lobby strips it, and so does coturn 4.17.2, checked by handing coturn a secret with a trailing space and a credential minted without one, which it accepted.
+
+Check: you have the string, and you have not run `openssl rand` twice.
+
+### 5. Write turnserver.conf
+
+```bash
+cp turnserver.conf.example turnserver.conf
+nano turnserver.conf
+```
+
+Copy the file before starting anything, because Docker creates a directory where a missing bind mount source should be and coturn then starts with no configuration at all.
+
+Set `static-auth-secret` to the string from step 4, put the six numbers from step 3 in, and set `realm` and `external-ip` from step 2. Every value in the template that is a deployment choice is tagged `EXAMPLE`, and the comment above it says what the choice is. Do not ship the example numbers.
+
+TLS on 5349 is worth having later for players whose network blocks plain UDP, and it needs a certificate from a CA their clients already trust. Leave it commented out for now and add it once the plain path works. [TLS on 5349](../../README.md#tls-on-5349) covers what it needs.
+
+Check: no line in the file still says `EXAMPLE` above a value you have not thought about, and `static-auth-secret` is not `REPLACE_ME_BEFORE_USE`.
+
+### 6. Open the ports
+
+```bash
+sudo ufw allow 3478/udp
+sudo ufw allow 3478/tcp
+sudo ufw allow 49152:49401/udp   # must match min-port..max-port in turnserver.conf
+```
+
+The third line opens a range, which is a much bigger hole than the single port the lobby already has open. Size it deliberately. [Ports and firewall](../../README.md#ports-and-firewall) covers this, including the cloud provider firewall you also have to open if you are on a VPS.
+
+Check: the range in the firewall rule is the same range as `min-port`..`max-port` in the config. Step 8 tells you if it is not.
+
+### 7. Start coturn
+
+On the lobby machine, under Compose:
+
+```bash
+docker compose --profile relay up -d
+docker compose logs -f coturn
+```
+
+On its own host, [Setting it up on its own host](../../README.md#setting-it-up-on-its-own-host) has the plain `docker run` and the distribution package route.
+
+Then, from a machine outside your network rather than from the relay itself:
+
+```bash
+turnutils_stunclient -p 3478 relay.example.org
+```
+
+Check: one line naming the address it saw you at.
+
+```
+INFO IPv4. UDP reflexive addr: 203.0.113.5:63944
+```
+
+Nothing back means port 3478 is closed or coturn is not running. The startup log should name the version, `INFO Coturn Version Coturn-4.17.2 'Gorst'`, and carry no `ERROR` lines.
+
+### 8. Prove a credential opens an allocation
+
+This is the step that proves the secret, the ports and the relaying all work at once, before the lobby depends on any of it. `turnutils_uclient` ships with coturn. Run it from outside your network.
+
+You need an echo peer with a public address. Run `turnutils_peer -p 3480` on some other machine and point `-e` at it.
+
+```bash
+secret=$(sed -n 's/^static-auth-secret=//p' turnserver.conf)
+turnuser="$(( $(date +%s) + 3600 )):1"
+turnpass=$(printf %s "$turnuser" | openssl dgst -sha1 -hmac "$secret" -binary | base64)
+turnutils_uclient -u "$turnuser" -w "$turnpass" -p 3478 -e 203.0.113.9 -r 3480 -n 3 relay.example.org
+```
+
+That mints a credential exactly as the lobby will, from the secret coturn itself loaded, so a pass here means the relay half is finished.
+
+Check: it ends with no lost packets.
+
+```
+INFO Total connect time is 0
+INFO start_mclient: tot_send_msgs=6, tot_recv_msgs=6
+INFO Total lost packets 0 (0.000000%), total send dropped 0 (0.000000%)
+```
+
+Two failures worth telling apart, both observed against coturn 4.17.2:
+
+- `ERROR Cannot complete Allocation`, and coturn logging `check_stun_auth: Cannot find credentials of user <...>`, is the credential. The secret you minted with is not the secret coturn loaded.
+- It runs to the end but reports `Total lost packets 6 (100.000000%)`. The credential and the allocation are fine and the packets are not getting to or from the peer, which is usually the allocation port range not being open through the firewall.
+
+If you have nowhere to run an echo peer, run it anyway with `-e` pointing at any address. You lose the second half of the test, but 100% packet loss instead of `Cannot complete Allocation` still tells you the credential was accepted and the allocation opened.
+
+[Telling the relay, the credential and the firewall apart](../../README.md#telling-the-relay-the-credential-and-the-firewall-apart) has the full table.
+
+## Turn the lobby on
+
+### 9. Write server_turn.txt
+
+On the lobby machine, three lines, in the lobby's working directory next to the other `server_*.txt` files:
+
+```
+turn:relay.example.org:3478
+<the secret from step 4>
+43200
+```
+
+Line 3 is optional and defaults to 43200 seconds. Do not go below 5115. The [`server_turn.txt` reference](../../README.md#server_turntxt---relay-hosting-turn) has that figure and where it comes from, and the server logs a warning at startup if you set less.
+
+Use `turns:` on port 5349 instead if you turned TLS on.
+
+Under Compose the file has to be mounted into the container to be read at all, because the lobby reads it from its working directory and that is `/app` inside the container. `docker-compose.yml` has the line commented out next to the motd and agreement mounts. Uncomment it and put `server_turn.txt` next to `docker-compose.yml`.
+
+Now check the two copies of the secret match, which is the one thing nothing else will catch. On the lobby:
+
+```bash
+sed -n 2p server_turn.txt | tr -d '[:space:]' | openssl dgst -sha256
+```
+
+On the relay:
+
+```bash
+sed -n 's/^static-auth-secret=//p' turnserver.conf | tr -d '[:space:]' | openssl dgst -sha256
+```
+
+Check: the two hashes are identical.
+
+```
+SHA2-256(stdin)= 3eb1bd439947eb762998e566ccc2e099c791118b2f40579cc4f7da2b5061b7f9
+SHA2-256(stdin)= 3eb1bd439947eb762998e566ccc2e099c791118b2f40579cc4f7da2b5061b7f9
+```
+
+Then restart the lobby. Under Compose, use `docker compose up -d uberserver` rather than `restart`, because you have just changed `docker-compose.yml` and a restart reuses the old container without the new mount. Either way the relay is left alone, so any relayed games already running survive it.
+
+Check: the lobby log has the line naming your URI.
+
+```
+INFO  DataHandler.parseFiles  Relay hosting enabled: TURN turn:relay.example.org:3478, credential lifetime 43200s
+```
+
+`No server_turn.txt found, relay hosting is disabled.` means the file is not where the lobby is looking. `Could not load server_turn.txt, relay hosting is disabled:` means it found it and the contents are wrong, and the rest of the line says how.
+
+### 10. Check the lobby is advertising the feature
+
+`LISTCOMPFLAGS` is answerable before login, so you can ask the lobby directly and skip the lobby client:
+
+```bash
+{ printf 'LISTCOMPFLAGS\n'; sleep 2; } | nc -w 3 127.0.0.1 8200
+```
+
+Check: `r` is in the reply.
+
+```
+TASSERVER unknown * 8201 0
+COMPFLAGS u sp b jsonchat r
+```
+
+The first line is the server's own greeting, and the version and NAT port in it will be yours.
+
+Without a relay configured the same command answers `COMPFLAGS u sp b jsonchat`, with no `r`. That is a typo in `server_turn.txt` or a lobby that was not restarted, not a problem with the relay, and it is worth ruling out before anybody starts blaming coturn. `r` is what tells a client the feature exists at all, and it also gates the `CLIENTIP` messages a relay host needs. [PROTOCOL.md 7.1](../../PROTOCOL.md#71-relay-hosting-turncredentials-clientip-relayedhost-moverelayedhost) has the wire detail.
+
+### 11. Expect your players to notice nothing
+
+Relay hosting is only offered by clients that support it. A client that does not send `r` at login is never told the feature exists, never receives a `CLIENTIP`, and behaves byte for byte as it did before you started. For most of your players, turning this on changes nothing they can see, and it is not a thing to announce to everybody.
+
+What changed is that a player on a client that does support it, who could not host before because they cannot forward a port, can now host. They do not have to do anything differently. Their client asks the lobby for a credential, opens an allocation, and the battle appears in the list like any other.
+
+Check: somebody on a supporting client can open a battle that other people can join, and the relay logs a session while they do. Follow it with `docker compose logs -f coturn`.
+
+## Afterwards
+
+### 12. Moving the relay to its own machine
+
+The lobby never connects to the relay, so this is smaller than it sounds. [The lobby does not care where the relay runs](../../README.md#the-lobby-does-not-care-where-the-relay-runs).
+
+1. Build the new relay and prove it, steps 5 to 8, with the same secret from step 4. Nothing in this repository has to be on that machine, just `turnserver.conf`.
+2. Change line 1 of `server_turn.txt` to the new address. Leave lines 2 and 3 alone.
+3. Restart the lobby, and repeat step 10 to confirm it still advertises `r`.
+
+The one thing to time properly is stopping the old relay. A relayed battle outlives the lobby connection that started it, so games are still running on the old relay after the lobby has stopped sending anyone to it. Leave it up until they finish.
+
+### When it does not work
+
+The README has a triage table that tells the relay, the credential and the firewall apart from what you can see. [Telling the relay, the credential and the firewall apart](../../README.md#telling-the-relay-the-credential-and-the-firewall-apart).
+
+If every check in this runbook passes and battles still fail, it is not the relay and not the lobby config. Start from the client.

--- a/protocol/Battle.py
+++ b/protocol/Battle.py
@@ -48,6 +48,14 @@ class Battle(Channel):
 
 		host = self._root.clientFromSession(self.host)
 		if client!=host:
+			# A relay host has to pre-authorise the joiner's address on the TURN server before
+			# the joiner's engine sends anything, because TURN drops traffic from an address it
+			# holds no permission for and tells neither end (RFC 5766 9.3). The joiner cannot
+			# supply the address itself: the packets that would carry it are the dropped ones.
+			# So it goes out first, ahead of JOINEDBATTLE, and only to a host that asked for
+			# relay support on a server that has a relay. Nobody else's conversation changes.
+			if 'r' in host.compat and self._root.turn_enabled():
+				host.Send('CLIENTIP %s %s' % (client.username, self._root.protocol.publicIP(client)))
 			self._root.broadcast('JOINEDBATTLE %s %s' % (self.battle_id, client.username), ignore=set([self.host, client.session_id])) 
 			scriptPassword = client.scriptPassword
 			if scriptPassword and 'sp' in host.compat:

--- a/protocol/Battle.py
+++ b/protocol/Battle.py
@@ -13,6 +13,7 @@ class Battle(Channel):
 		self.type = ''
 		self.natType = ''
 		self.port = 0
+		self.relayed_ip = None # set from RELAYEDHOST when the host is relayed, None otherwise
 
 		self.title = ''
 		self.map = ''

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -8,6 +8,8 @@ import socket
 import logging
 import datetime
 import base64
+import hashlib
+import hmac
 import json
 import traceback
 
@@ -112,6 +114,9 @@ restricted = {
 	'MYSTATUS',
 	'PORTTEST',
 	'JSON',
+	########
+	# relay hosting
+	'TURNCREDENTIALS',
 	########
 	# bridge bots
 	'BRIDGECLIENTFROM',
@@ -3257,13 +3262,60 @@ class Protocol:
 		client.Remove(reason)
 
 	def in_LISTCOMPFLAGS(self, client):
+		# 'r' is how a client learns whether this server offers relay hosting, so it is only
+		# advertised once a TURN server is configured. It stays in flag_map either way: a
+		# client that sends 'r' to a server with no relay must not be told its flag is
+		# unknown, it must simply get a clean TURNCREDENTIALSFAILED if it asks.
 		flags = ""
 		for flag in flag_map:
+			if flag == 'r' and not self._root.turn_enabled():
+				continue
 			if len(flags)>0:
 				flags += " " + flag
 			else:
 				flags = flag
 		client.Send("COMPFLAGS %s" %(flags))
+
+	def in_TURNCREDENTIALS(self, client):
+		'''
+		Request a time-limited TURN credential for relay hosting.
+
+		Replies TURNCREDENTIALS <uri> <username> <password> <ttl_seconds> on success, or
+		TURNCREDENTIALSFAILED <reason> otherwise. The scheme is
+		draft-uberti-behave-turn-rest-00, which coturn implements as use-auth-secret:
+		the username is "<unix expiry>:<lobby account id>" and the password is
+		base64(hmac_sha1(shared secret, username)). coturn recomputes both from the same
+		secret, so it never has to talk to the lobby or hold any session state.
+		'''
+		if not self._root.turn_enabled():
+			client.Send('TURNCREDENTIALSFAILED This server has no relay configured')
+			return
+
+		ttl = self._root.turn_ttl
+		username = '%d:%s' % (int(time.time()) + ttl, client.user_id)
+		password = base64.b64encode(hmac.new(self._root.turn_secret.encode('utf-8'), username.encode('utf-8'), hashlib.sha1).digest()).decode('utf-8')
+		uri = self._root.turn_uri
+
+		# The reply is exactly four space-separated fields and the client refuses the whole
+		# line if any of them is empty or shifted. Whitespace anywhere but the separators
+		# would do that silently, so check rather than trust: the URI comes from operator
+		# config and the account id has been a string on its way here.
+		for field in (uri, username, password):
+			if not field or any(c.isspace() for c in field):
+				logging.error('[%s] <%s>: refusing to send a malformed TURN credential' % (client.session_id, client.username))
+				client.Send('TURNCREDENTIALSFAILED Server could not build a valid credential, please tell an admin')
+				return
+
+		# Rate limit per account, matching in_REGISTER's per-IP limit and in_RENAMEACCOUNT's
+		# per-user one: 3 in flight, decaying by one every 20 minutes (server.py). Stays after
+		# the checks above so a request that got no credential does not burn a slot.
+		recent = self._root.recent_turn_credentials.get(client.user_id, 0)
+		if recent >= 3:
+			client.Send('TURNCREDENTIALSFAILED too many recent credential requests, please try again later')
+			return
+		self._root.recent_turn_credentials[client.user_id] = recent + 1
+
+		client.Send('TURNCREDENTIALS %s %s %s %d' % (uri, username, password, ttl))
 
 	def in_KICK(self, client, username, reason=''):
 		# kick target username from server

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -10,6 +10,7 @@ import datetime
 import base64
 import hashlib
 import hmac
+import ipaddress
 import json
 import traceback
 
@@ -117,6 +118,7 @@ restricted = {
 	########
 	# relay hosting
 	'TURNCREDENTIALS',
+	'RELAYEDHOST',
 	########
 	# bridge bots
 	'BRIDGECLIENTFROM',
@@ -609,6 +611,36 @@ class Protocol:
 			return client.local_ip
 		return client.ip_address
 
+	def _validRelayedHostAddress(self, ip):
+		# Returns (address, reason). RELAYEDHOST lets a client choose what everybody else is
+		# told to connect to, so the address has to be one the rest of the internet can reach
+		# before it goes anywhere near BATTLEOPENED.
+		try:
+			address = ipaddress.ip_address(ip)
+		except ValueError:
+			return None, '%s is not an IP address' % ip
+
+		# is_global is the whole public/not-public test and it covers both families, so IPv6
+		# is not an afterthought here: it is false for loopback, every private range, the
+		# link-local ranges, carrier-grade NAT and the documentation ranges. Multicast is the
+		# one gap in it, and a battle lives at one host rather than a group.
+		if not address.is_global or address.is_multicast:
+			return None, '%s is not a public address, so nobody could join a battle there' % ip
+
+		# The lobby's own address is a public one, and branch 2 of client_AddBattle already
+		# hands it out for port-forwarded hosts. A client naming it for itself would take
+		# that over, so it is refused however the operator has the lobby addressed.
+		for own in (self._root.online_ip, self._root.local_ip):
+			try:
+				if own and ipaddress.ip_address(own) == address:
+					return None, '%s is this lobby server, not a relay' % ip
+			except ValueError:
+				continue
+
+		# Canonical form, not the client's spelling: 2001:DB8::0:1 and 2001:db8::1 are one
+		# address and only one of them should ever reach a joining client.
+		return str(address), ''
+
 	def _validLegacyPasswordSyntax(self, password):
 		# checks if an old-style password is correctly encoded
 		if (not password):
@@ -788,6 +820,8 @@ class Protocol:
 
 		host = self.clientFromSession(battle.host)
 		# IP translation logic:
+		# 0. If the host named a relay address with RELAYEDHOST, that address is the battle,
+		#    for every recipient. Skip the rest.
 		# 1. If the joining client has the same WAN IP as the host, they are on the same LAN.
 		#    Send the host's local/LAN IP so they can connect directly.
 		# 2. If the host is on the same LAN as the lobby server (host's WAN IP matches the
@@ -808,7 +842,15 @@ class Protocol:
 					return False
 			return False
 
-		if host.ip_address == client.ip_address:
+		if battle.relayed_ip:
+			# A relayed battle lives at a TURN allocation on the relay, a public address on a
+			# machine the host does not own. The three branches below all work an address out
+			# from the host's own connection, so all three name the host's machine, which under
+			# a relay is the address nobody can reach. The same-WAN-IP branch included: two
+			# players behind one NAT still reach a relayed battle through the relay rather than
+			# across their own LAN, so there is no recipient this is worth skipping for.
+			translated_ip = battle.relayed_ip
+		elif host.ip_address == client.ip_address:
 			# Same WAN IP - both on same LAN, use host's local IP
 			translated_ip = host.local_ip
 		elif _is_private_ip(host.ip_address) and not _is_private_ip(client.ip_address):
@@ -2223,6 +2265,14 @@ class Protocol:
 		@required.sentence.str title: The battle's title.
 		@required.sentence.str modName: The mod name.
 		'''
+		# Consumed here rather than on the way out, ahead of the LEAVEBATTLE below which also
+		# forgets it, so that an address only ever belongs to the one OPENBATTLE it arrived
+		# with. A host whose OPENBATTLE is refused sends the pair again (coilbox builds both
+		# lines together), and an address that survived a refusal would be a stale one waiting
+		# to attach itself to some later battle.
+		relayed_ip = client.relayed_host_ip
+		client.relayed_host_ip = None
+
 		if client.current_battle:
 			self.in_LEAVEBATTLE(client)
 
@@ -2303,6 +2353,9 @@ class Protocol:
 		battle.type = type
 		battle.natType = natType
 		battle.port = port
+		# Unconditional: a Battle object is reused for the same host's next battle, so a
+		# relayed one must not leave its address behind for a later direct one.
+		battle.relayed_ip = relayed_ip
 		battle.title = title
 		battle.map = map
 		battle.maphash = maphash
@@ -2484,6 +2537,10 @@ class Protocol:
 		'''
 		Leave current battle.
 		'''
+		# A host that walks away without opening the battle it asked for should not have its
+		# relay address waiting for whatever it opens next.
+		client.relayed_host_ip = None
+
 		battle = self.getCurrentBattle(client)
 		if not battle:
 			self.out_FAILED(client, "LEAVEBATTLE", "not in battle")
@@ -3323,6 +3380,54 @@ class Protocol:
 		self._root.recent_turn_credentials[client.user_id] = recent + 1
 
 		client.Send('TURNCREDENTIALS %s %s %s %d' % (uri, username, password, ttl))
+
+	def in_RELAYEDHOST(self, client, ip, port):
+		'''
+		Name the address the next battle this client opens is reachable at.
+
+		Sent immediately before OPENBATTLE by a host whose battle lives at a TURN allocation
+		on the relay rather than on its own machine. The server cannot work that address out:
+		everything it knows about the host is the connection the host is talking to it on, and
+		that is the machine nobody can reach, which is the reason the allocation exists.
+
+		The address is held against the client and consumed by its next OPENBATTLE, so it can
+		never outlive the one battle it was sent for. natType is untouched: a TURN allocation
+		is an ordinary public UDP address and a joining client needs to understand nothing.
+
+		Refused as RELAYEDHOSTFAILED <reason>, free text meant to be read by whoever is
+		trying to host.
+
+		@required.str ip: The relay allocation's address, IPv4 or IPv6.
+		@required.int port: The relay allocation's port. The battle is advertised at the port
+		OPENBATTLE carries. This one is here because a rebuilt allocation moves the address
+		and the port together.
+		'''
+		if not self._root.turn_enabled():
+			client.Send('RELAYEDHOSTFAILED This server has no relay configured')
+			return
+
+		# Unlike TURNCREDENTIALS, which hands out something a client can only use, this
+		# decides what other people are told to connect to. A client that did not ask for
+		# relay support has no business naming its own address.
+		if 'r' not in client.compat:
+			client.Send('RELAYEDHOSTFAILED Your client did not ask for relay support at login')
+			return
+
+		try:
+			port = int(port)
+		except ValueError:
+			client.Send('RELAYEDHOSTFAILED Port is not a number: %s' % port)
+			return
+		if port < 1 or port > 65535:
+			client.Send('RELAYEDHOSTFAILED Port is out of range: 1-65535: %d' % port)
+			return
+
+		address, reason = self._validRelayedHostAddress(ip)
+		if not address:
+			client.Send('RELAYEDHOSTFAILED %s' % reason)
+			return
+
+		client.relayed_host_ip = address
 
 	def in_KICK(self, client, username, reason=''):
 		# kick target username from server

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -600,7 +600,15 @@ class Protocol:
 
 	def _validateIP(self, ipAddress):
 		return self.ipRegex_compiled.match(ipAddress)
-	
+
+	def publicIP(self, client):
+		# The address the rest of the internet sees this client at, which is not always the
+		# address it is connected from: behind a trusted proxy the socket carries the proxy's
+		# address and the client's own arrives in the LOGIN local_ip field (_login_finish_now).
+		if client.ip_address in self._root.trusted_proxies:
+			return client.local_ip
+		return client.ip_address
+
 	def _validLegacyPasswordSyntax(self, password):
 		# checks if an old-style password is correctly encoded
 		if (not password):
@@ -2356,8 +2364,7 @@ class Protocol:
 				client.Send('JOINBATTLEFAILED Waiting for JOINBATTLEACCEPT/JOINBATTLEDENIED from host')
 			else:
 				self.addPendingBattle(client, battle)
-			client_ip = client.local_ip if client.ip_address in self._root.trusted_proxies else client.ip_address
-			host.Send('JOINBATTLEREQUEST %s %s' % (username, client_ip))
+			host.Send('JOINBATTLEREQUEST %s %s' % (username, self.publicIP(client)))
 			return
 		self.removePendingBattle(client)
 		battle.joinBattle(client)

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -119,6 +119,7 @@ restricted = {
 	# relay hosting
 	'TURNCREDENTIALS',
 	'RELAYEDHOST',
+	'MOVERELAYEDHOST',
 	########
 	# bridge bots
 	'BRIDGECLIENTFROM',
@@ -766,6 +767,17 @@ class Protocol:
 	def broadcast_RemoveBattle(self, battle):
 		for cid, client in self._root.usernames.items():
 			client.Send('BATTLECLOSED %s' % battle.battle_id)
+
+	def broadcast_MoveBattle(self, battle):
+		'''sends the protocol for a battle that changed address without closing'''
+		# Gated on 'r' for the same reason CLIENTIP is. This is the only message in the
+		# protocol that changes a battle's address after BATTLEOPENED, so no client that
+		# predates relay hosting has a handler for it, and 'r' is exactly the flag that says
+		# "I understand relay-hosted battles". A client without it sees nothing new.
+		for cid, client in self._root.usernames.items():
+			if 'r' not in client.compat:
+				continue
+			client.Send('BATTLEHOSTMOVED %s %s %s' % (battle.battle_id, battle.relayed_ip, battle.port))
 
 	def broadcast_SendBattle(self, battle, data, sourceClient=None, flag=None, not_flag=None):
 		# the sourceClient is only sent for SAY*, and RING commands
@@ -3399,8 +3411,8 @@ class Protocol:
 
 		@required.str ip: The relay allocation's address, IPv4 or IPv6.
 		@required.int port: The relay allocation's port. The battle is advertised at the port
-		OPENBATTLE carries. This one is here because a rebuilt allocation moves the address
-		and the port together.
+		OPENBATTLE carries, so this one is range-checked and then discarded. MOVERELAYEDHOST
+		is the command whose port is used, because there is no OPENBATTLE behind it.
 		'''
 		if not self._root.turn_enabled():
 			client.Send('RELAYEDHOSTFAILED This server has no relay configured')
@@ -3428,6 +3440,86 @@ class Protocol:
 			return
 
 		client.relayed_host_ip = address
+
+	def in_MOVERELAYEDHOST(self, client, ip, port):
+		'''
+		Move the open battle this client is hosting to a new relay address and port.
+
+		Sent on its own, with no OPENBATTLE behind it, by a relay host whose TURN allocation
+		was lost and rebuilt somewhere else. The room and everybody in it stay where they are,
+		which is the whole point: closing and reopening the battle would empty it.
+
+		This is a separate command from RELAYEDHOST rather than the same one told apart by
+		whether the sender is already hosting, because that test does not tell them apart. A
+		relay host reopening its battle sends RELAYEDHOST while still hosting the old one, and
+		in_OPENBATTLE reads the staged address before the in_LEAVEBATTLE that closes it. One
+		command would read that RELAYEDHOST as a move, apply it to a battle about to be
+		destroyed, and leave the new battle advertised at the host's own unreachable machine.
+
+		The port here is used, unlike RELAYEDHOST's. There is no OPENBATTLE to carry one, and
+		a rebuilt allocation moves the address and the port together, so dropping it would
+		move the battle to the right address on the wrong port and leave it just as
+		unreachable as before.
+
+		A battle that was never relayed is refused. Everybody already in it, and every battle
+		list on the server, holds a direct address that still works, and there is no message
+		that can correct them, so converting it would break a working battle rather than
+		repair a broken one. A battle's addressing scheme is fixed for its lifetime.
+
+		natType is untouched, as at OPENBATTLE: a TURN allocation is an ordinary public UDP
+		address and a joining client needs to understand nothing.
+
+		On success, BATTLEHOSTMOVED <battle_id> <ip> <port> goes to every logged-in client
+		that asked for relay support, including the host. Refused as MOVERELAYEDHOSTFAILED
+		<reason>, free text meant to be read by whoever is trying to host.
+
+		@required.str ip: The rebuilt allocation's address, IPv4 or IPv6.
+		@required.int port: The rebuilt allocation's port. This is the port the battle is
+		advertised at from now on.
+		'''
+		if not self._root.turn_enabled():
+			client.Send('MOVERELAYEDHOSTFAILED This server has no relay configured')
+			return
+
+		if 'r' not in client.compat:
+			client.Send('MOVERELAYEDHOSTFAILED Your client did not ask for relay support at login')
+			return
+
+		battle = self.getCurrentBattle(client)
+		if not battle:
+			client.Send('MOVERELAYEDHOSTFAILED You are not hosting a battle')
+			return
+
+		# Explicit, and ahead of everything else about the battle: a spectator sitting in
+		# somebody else's battle must not be able to send everybody in it to an address of
+		# its choosing. canChangeSettings is the host test every other host-only command uses.
+		if not battle.canChangeSettings(client):
+			client.Send('MOVERELAYEDHOSTFAILED Only the host of a battle can move it')
+			return
+
+		if not battle.relayed_ip:
+			client.Send('MOVERELAYEDHOSTFAILED This battle was not opened through a relay')
+			return
+
+		try:
+			port = int(port)
+		except ValueError:
+			client.Send('MOVERELAYEDHOSTFAILED Port is not a number: %s' % port)
+			return
+		if port < 1 or port > 65535:
+			client.Send('MOVERELAYEDHOSTFAILED Port is out of range: 1-65535: %d' % port)
+			return
+
+		address, reason = self._validRelayedHostAddress(ip)
+		if not address:
+			client.Send('MOVERELAYEDHOSTFAILED %s' % reason)
+			return
+
+		battle.relayed_ip = address
+		battle.port = port
+		# Anybody who joins or logs in after this reads the new pair out of the battle, so
+		# BATTLEHOSTMOVED only has to reach the clients already holding the old one.
+		self.broadcast_MoveBattle(battle)
 
 	def in_KICK(self, client, username, reason=''):
 		# kick target username from server

--- a/server.py
+++ b/server.py
@@ -68,6 +68,8 @@ try:
 	recent_registration_loop.start(60*20)
 	recent_rename_loop = task.LoopingCall(_root.decrement_recent_renames)
 	recent_rename_loop.start(60*60*24*7)
+	recent_turn_credential_loop = task.LoopingCall(_root.decrement_recent_turn_credentials)
+	recent_turn_credential_loop.start(60*20)
 
 	# 3.1: size the reactor thread pool for off-reactor DB work (deferToThread).
 	reactor.suggestThreadPoolSize(_root.max_threads)

--- a/tests/integration/joineraddresstest.py
+++ b/tests/integration/joineraddresstest.py
@@ -1,0 +1,166 @@
+"""
+End-to-end tier: joiner addresses (issue #28) against a server with no TURN relay configured.
+
+The shared test server boots without a server_turn.txt, which is the state every existing
+deployment is in, so the property under test here is the negative one: a battle join must look
+exactly as it did before, whether or not the host asked for relay support. The same battle is
+hosted twice, once by a host advertising 'r' and once by a host that does not, and the two
+hosts' received streams are compared line for line rather than merely searched for CLIENTIP.
+
+The configured half, where a relay host is sent CLIENTIP with the joiner's public address, is
+covered in-process by tests/worker/joineraddressworkertest.py, which needs no server and
+cannot be disturbed by whatever config the operator has left in the repository root.
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import HOST, PORT
+import socket, ssl, hashlib, base64, re, time, sys
+
+raw_pw = "secretpw"
+PW = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+HOST_R = "jaddrhostr"
+HOST_PLAIN = "jaddrhostp"
+JOINER = "jaddrjoiner"
+
+# hosting requires TLS (in_OPENBATTLE), and the test server's certificate is self-signed
+CTX = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class Client:
+    def __init__(self):
+        self.s = socket.create_connection((HOST, PORT))
+        self.buf = ""
+        self.read_for(0.5)
+        self.send("STLS")
+        self.read_until("OK", 5)
+        self.s = CTX.wrap_socket(self.s)
+        self.read_for(0.5)
+
+    def send(self, line):
+        self.s.sendall((line + "\n").encode())
+
+    def read_until(self, substr, timeout=8):
+        deadline = time.time() + timeout
+        while substr not in self.buf and time.time() < deadline:
+            self.s.settimeout(max(0.1, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def read_for(self, seconds):
+        """Drain everything that arrives in a fixed window, for streams with no end marker."""
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.s.settimeout(max(0.05, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def close(self):
+        try: self.s.close()
+        except OSError: pass
+
+
+def register(user):
+    c = Client()
+    c.send("REGISTER %s %s" % (user, PW))
+    print("REGISTER %s -> %s" % (user, c.read_until("\n", 5).strip()))
+    c.close()
+
+
+def login(user, flags):
+    c = Client()
+    c.send("LOGIN %s %s 0 * TestClient\t0\t%s" % (user, PW, flags))
+    got = c.read_until("AGREEMENTEND", 10)
+    if "AGREEMENTEND" in got:
+        c.send("CONFIRMAGREEMENT")
+        got += c.read_until("LOGININFOEND", 10)
+    check("LOGININFOEND" in got, "%s should log in, got:\n%s" % (user, got))
+    return c
+
+
+def open_battle(host, title):
+    host.send("OPENBATTLE 0 0 * 8452 8 4660 0 4660 spring\t105.0\tDeltaSiegeDry\t%s\tBA" % title)
+    opened = host.read_for(1.5)
+    battle_id = None
+    for line in opened.splitlines():
+        if line.startswith("BATTLEOPENED "):
+            battle_id = line.split(" ")[1]
+    check(battle_id is not None, "OPENBATTLE should produce a BATTLEOPENED, got:\n%s" % opened)
+    return battle_id
+
+
+def normalise(lines, host_user, battle_id):
+    """Strip the parts that differ by construction: the host's name and the battle id."""
+    out = []
+    for line in lines:
+        if not line.strip():
+            continue
+        line = re.sub(r"__battle__\d+", "BCHAN", line.strip()).replace(host_user, "HOST")
+        out.append(re.sub(r"(?<= )%s(?= |$)" % re.escape(battle_id), "BID", line))
+    return out
+
+
+def hosted_join(host_user, flags):
+    """Host a battle, have the joiner join it, and hand back what the host saw."""
+    host = login(host_user, flags)
+    battle_id = open_battle(host, "relay join test")
+    joiner = login(JOINER, "u sp")
+    joiner.read_for(0.5)
+    host.read_for(0.5)  # discard the joiner's ADDUSER etc, keeping only the join itself
+
+    joiner.send("JOINBATTLE %s" % battle_id)
+    joiner.read_for(1.5)
+    seen = host.read_for(1.5)
+
+    joiner.send("LEAVEBATTLE")
+    joiner.read_for(0.5)
+    joiner.close()
+    host.close()
+    time.sleep(0.5)  # let the server tear the battle down before the next one opens
+    return normalise(seen.splitlines(), host_user, battle_id)
+
+
+for user in (HOST_R, HOST_PLAIN, JOINER):
+    register(user)
+print("waiting 3s for the delayed-registration window...")
+time.sleep(3)
+
+relay_host = hosted_join(HOST_R, "u sp r")
+plain_host = hosted_join(HOST_PLAIN, "u sp")
+print("host with 'r'    ->", relay_host)
+print("host without 'r' ->", plain_host)
+
+check(any(line.startswith("JOINEDBATTLE ") for line in relay_host),
+      "the join should have happened at all, got %r" % (relay_host,))
+check(not any(line.startswith("CLIENTIP ") for line in relay_host),
+      "no relay is configured, so no CLIENTIP should be sent, got %r" % (relay_host,))
+check(relay_host == plain_host,
+      "advertising 'r' must not change the conversation on a relay-less server:\n  %r\n  %r"
+      % (relay_host, plain_host))
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/integration/moverelayedhostrelaytest.py
+++ b/tests/integration/moverelayedhostrelaytest.py
@@ -1,0 +1,307 @@
+"""
+End-to-end tier: MOVERELAYEDHOST (issue #43) against a server that has a relay configured.
+
+The shared test server boots without a server_turn.txt, so this script brings its own: a
+second lobby server, on its own port, started from a temporary directory holding nothing but
+a server_turn.txt. That keeps the configured half of relay hosting testable over real sockets
+without touching whatever config the operator has left in the repository root.
+
+What it proves, over the wire, with a battle that stays open the whole time:
+  - a host moves its battle and a client joining afterwards is told the new address AND the
+    new port. The port is the trap: a rebuilt TURN allocation moves both, MOVERELAYEDHOST is
+    the only line carrying either, and a move that updated the address alone would leave the
+    battle exactly as unreachable as it was
+  - a client already holding the battle in its list is told, if it asked for relay support
+  - a client that did not ask for relay support is told nothing at all
+  - a non-host sitting in the battle cannot move it
+  - a private address is refused, and the battle stays where it was
+  - a battle opened without a relay is not convertible into a relayed one
+
+The relay-less refusals are in moverelayedhosttest.py, which uses the shared server.
+"""
+import os as _os, sys as _sys
+_ROOT = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir))
+_sys.path[:0] = [_ROOT, _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+import base64, hashlib, shutil, socket, ssl, subprocess, sys, tempfile, time
+
+import testenv
+
+HOST = testenv.HOST
+PORT = testenv.PORT + 100  # its own server, so it cannot collide with the shared one
+NATPORT = PORT + 1
+
+RAW_PW = "secretpw"
+PW = base64.b64encode(hashlib.md5(RAW_PW.encode()).digest()).decode()
+
+# Real public addresses: the documentation ranges are refused along with everything else
+# nobody can route to.
+OPEN_IP, OPEN_PORT = "185.199.108.153", "30001"
+MOVED_IP, MOVED_PORT = "151.101.1.140", "41234"
+
+CTX = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)  # hosting requires TLS, the cert is self-signed
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class Client:
+    def __init__(self):
+        self.s = socket.create_connection((HOST, PORT))
+        self.buf = ""
+        self.read_for(0.5)
+        self.send("STLS")
+        self.read_until("OK", 5)
+        self.s = CTX.wrap_socket(self.s)
+        self.read_for(0.5)
+
+    def send(self, line):
+        self.s.sendall((line + "\n").encode())
+
+    def read_until(self, substr, timeout=8):
+        deadline = time.time() + timeout
+        while substr not in self.buf and time.time() < deadline:
+            self.s.settimeout(max(0.1, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def read_for(self, seconds):
+        """Drain everything that arrives in a fixed window, for streams with no end marker."""
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.s.settimeout(max(0.05, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def close(self):
+        try: self.s.close()
+        except OSError: pass
+
+
+def register(user):
+    c = Client()
+    c.send("REGISTER %s %s" % (user, PW))
+    c.read_until("\n", 5)
+    c.close()
+
+
+def login(user, flags):
+    c = Client()
+    c.send("LOGIN %s %s 0 * TestClient\t0\t%s" % (user, PW, flags))
+    got = c.read_until("AGREEMENTEND", 10)
+    if "AGREEMENTEND" in got:
+        c.send("CONFIRMAGREEMENT")
+        got += c.read_until("LOGININFOEND", 10)
+    check("LOGININFOEND" in got, "%s should log in, got:\n%s" % (user, got))
+    c.login_text = got  # the battle list arrives during login, ahead of LOGININFOEND
+    return c
+
+
+def battleopened(text, battle_id=None):
+    """The last BATTLEOPENED in a stream, optionally for one battle."""
+    for line in reversed(text.splitlines()):
+        if line.startswith("BATTLEOPENED ") and (battle_id is None or line.split(" ")[1] == battle_id):
+            return line
+    return ""
+
+
+def refusal(text):
+    """The MOVERELAYEDHOSTFAILED line in a stream, which arrives among unrelated traffic.
+
+    Other people log in and out while a test runs, so ADDUSER and REMOVEUSER turn up in the
+    same read. Match on the line, not on the front of the buffer.
+    """
+    for line in text.splitlines():
+        if line.startswith("MOVERELAYEDHOSTFAILED "):
+            return line.strip()
+    return ""
+
+
+def pair(line):
+    """The (address, port) a client would dial for this battle: fields 5 and 6."""
+    fields = line.split(" ")
+    return (fields[5], fields[6]) if len(fields) > 6 else ("", "")
+
+
+def open_relayed_battle(host, ip=OPEN_IP, port=OPEN_PORT, relayed=True, title="move test"):
+    if relayed:
+        host.send("RELAYEDHOST %s %s" % (ip, port))
+        got = host.read_for(0.6)
+        check("RELAYEDHOSTFAILED" not in got,
+              "RELAYEDHOST should be accepted, got %r" % (got,))
+    host.send("OPENBATTLE 0 0 * %s 8 4660 0 4660 spring\t105.0\tDeltaSiegeDry\t%s\tBA"
+              % (port, title))
+    opened = host.read_for(1.5)
+    line = battleopened(opened)
+    check(line != "", "OPENBATTLE should produce a BATTLEOPENED, got:\n%s" % opened)
+    return line.split(" ")[1]
+
+
+def start_server(workdir):
+    env = dict(_os.environ)
+    env["PYTHONPATH"] = _os.pathsep.join(
+        [_ROOT, _os.path.join(_ROOT, "protocol")]
+        + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else []))
+    with open(_os.path.join(workdir, "server_turn.txt"), "w") as f:
+        f.write("turn:relay.example.org:3478\na_long_random_shared_secret\n")
+    proc = subprocess.Popen(
+        [sys.executable, _os.path.join(_ROOT, "server.py"),
+         "-p", str(PORT), "-n", str(NATPORT), "-s", testenv.DB_URL],
+        cwd=workdir, env=env)
+    deadline = time.time() + 40
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((HOST, PORT), timeout=2) as s:
+                s.settimeout(2)
+                if s.recv(64):
+                    return proc
+        except OSError:
+            time.sleep(0.3)
+    proc.terminate()
+    raise SystemExit("relay-configured lobby server did not become ready on %s:%d" % (HOST, PORT))
+
+
+HOSTU, INROOM, PLAIN, LATE1, LATE2, LATE3, DIRECT = (
+    "mvrhost", "mvrinroom", "mvrplain", "mvrlate1", "mvrlate2", "mvrlate3", "mvrdirect")
+
+workdir = tempfile.mkdtemp(prefix="uberserver-relay-")
+proc = start_server(workdir)
+try:
+    for user in (HOSTU, INROOM, PLAIN, LATE1, LATE2, LATE3, DIRECT):
+        register(user)
+    print("waiting 3s for the delayed-registration window...")
+    time.sleep(3)
+
+    # --- a relayed battle, opened and then moved ------------------------------------
+    host = login(HOSTU, "u sp r")
+    battle_id = open_relayed_battle(host)
+
+    inroom = login(INROOM, "u sp r")     # asks for relay support, and sits in the battle
+    plain = login(PLAIN, "u sp")         # does not, and only watches the list
+    before_inroom = battleopened(inroom.login_text, battle_id)
+    before_plain = battleopened(plain.login_text, battle_id)
+    check(pair(before_inroom) == (OPEN_IP, OPEN_PORT),
+          "the battle should open at the relay pair, got %r" % (before_inroom,))
+    check(pair(before_plain) == (OPEN_IP, OPEN_PORT),
+          "every client should see the same opening pair, got %r" % (before_plain,))
+
+    inroom.send("JOINBATTLE %s * sp1" % battle_id)
+    inroom.read_until("REQUESTBATTLESTATUS", 5)
+    host.read_for(0.5)
+    plain.read_for(0.5)
+
+    host.send("MOVERELAYEDHOST %s %s" % (MOVED_IP, MOVED_PORT))
+    host_saw = host.read_for(1.0)
+    inroom_saw = inroom.read_for(1.0)
+    plain_saw = plain.read_for(1.0)
+    print("host after the move  ->", host_saw.strip().replace("\n", " | "))
+    print("in-room 'r' client   ->", inroom_saw.strip().replace("\n", " | "))
+    print("client without 'r'   ->", repr(plain_saw))
+
+    expected = "BATTLEHOSTMOVED %s %s %s" % (battle_id, MOVED_IP, MOVED_PORT)
+    check(expected in inroom_saw,
+          "an 'r' client holding the battle should be told it moved, expected %r, got %r"
+          % (expected, inroom_saw))
+    check(expected in host_saw,
+          "the host should get its own move back as the acknowledgement, got %r" % (host_saw,))
+    check("MOVERELAYEDHOSTFAILED" not in host_saw,
+          "a valid move should not be refused, got %r" % (host_saw,))
+    check("BATTLEHOSTMOVED" not in plain_saw and MOVED_IP not in plain_saw,
+          "a client that did not ask for relay support should not be told the battle moved, "
+          "got %r" % (plain_saw,))
+
+    # the whole point: a client that turns up afterwards dials the rebuilt allocation
+    late = login(LATE1, "u sp")
+    moved_line = battleopened(late.login_text, battle_id)
+    print("battle after the move ->", moved_line)
+    check(pair(moved_line) == (MOVED_IP, MOVED_PORT),
+          "a client arriving after the move should be told the new address and port, got %r"
+          % (moved_line,))
+    check(moved_line.split(" ")[3] == "0",
+          "natType should still be 0 after a move, got %r" % (moved_line,))
+    # everything but the pair is the line it was
+    def blanked(line):
+        f = line.split(" ")
+        f[5], f[6] = "IP", "PORT"
+        return " ".join(f)
+    check(blanked(moved_line) == blanked(before_plain),
+          "only the address and port should differ across a move:\n  %r\n  %r"
+          % (before_plain, moved_line))
+    late.close()
+
+    # --- a non-host in the battle cannot move it -------------------------------------
+    inroom.send("MOVERELAYEDHOST %s %s" % (OPEN_IP, OPEN_PORT))
+    said = refusal(inroom.read_for(1.0))
+    print("non-host move        ->", said)
+    check(said != "", "a non-host sitting in the battle should be refused")
+    check(len(said.split(" ", 1)[-1]) > 10,
+          "the refusal should carry a reason a person can read, got %r" % (said,))
+
+    # --- a private, loopback or malformed address is refused --------------------------
+    for bad, why in (("192.168.1.10", "a private address"), ("127.0.0.1", "loopback"),
+                     ("not.an.address", "a string that is not an address")):
+        host.send("MOVERELAYEDHOST %s 5000" % bad)
+        said = refusal(host.read_for(0.8))
+        print("move to %-31s ->" % why, said)
+        check(said != "", "%s (%r) should be refused, got nothing" % (why, bad))
+
+    late = login(LATE2, "u sp")
+    still = battleopened(late.login_text, battle_id)
+    check(pair(still) == (MOVED_IP, MOVED_PORT),
+          "a refused move must leave the battle where it was, got %r" % (still,))
+    late.close()
+
+    inroom.close()
+    plain.close()
+    host.close()
+    time.sleep(0.5)  # let the server tear the battle down before the next one opens
+
+    # --- a battle opened without a relay is not converted -----------------------------
+    direct = login(DIRECT, "u sp r")
+    direct_id = open_relayed_battle(direct, relayed=False, port="30002", title="direct test")
+    watcher = login(LATE3, "u sp r")
+    direct_before = battleopened(watcher.login_text, direct_id)
+    watcher.read_for(0.3)
+
+    direct.send("MOVERELAYEDHOST %s %s" % (MOVED_IP, MOVED_PORT))
+    said = refusal(direct.read_for(1.0))
+    announced = watcher.read_for(0.8)
+    print("move a direct battle ->", said)
+    check(said != "", "a battle opened without a relay should not be convertible")
+    check("BATTLEHOSTMOVED" not in announced,
+          "a refused conversion must announce nothing, got %r" % (announced,))
+    check(pair(direct_before)[1] == "30002",
+          "the direct battle should have opened at its OPENBATTLE port, got %r" % (direct_before,))
+
+    watcher.close()
+    direct.close()
+finally:
+    proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    shutil.rmtree(workdir, ignore_errors=True)
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/integration/moverelayedhosttest.py
+++ b/tests/integration/moverelayedhosttest.py
@@ -1,0 +1,191 @@
+"""
+End-to-end tier: MOVERELAYEDHOST (issue #43) against a server with no TURN relay configured.
+
+The shared test server boots without a server_turn.txt, which is the state every existing
+deployment is in, so the properties under test here are the negative ones. A move is refused
+with a reason somebody can read, whether or not the sender is hosting anything, and a battle
+whose host sent one is advertised exactly as it would have been if the line had never been
+sent. Two battles are opened, one by a host that tries to move it and one by a host that does
+not, and what an onlooker is told about each is compared line for line.
+
+The configured half, where the battle really does move, is covered over real sockets by
+moverelayedhostrelaytest.py, which brings its own relay-configured server, and in-process by
+tests/worker/moverelayedhostworkertest.py.
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import HOST, PORT
+import socket, ssl, hashlib, base64, re, time, sys
+
+raw_pw = "secretpw"
+PW = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+HOST_MOVE = "mvnrhostm"
+HOST_PLAIN = "mvnrhostp"
+IDLE = "mvnridle"
+WATCHER = "mvnrwatcher"
+RELAY_IP = "185.199.108.153"  # a real public address: the documentation ranges are refused
+MOVED_IP = "151.101.1.140"
+
+# hosting requires TLS (in_OPENBATTLE), and the test server's certificate is self-signed
+CTX = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class Client:
+    def __init__(self):
+        self.s = socket.create_connection((HOST, PORT))
+        self.buf = ""
+        self.read_for(0.5)
+        self.send("STLS")
+        self.read_until("OK", 5)
+        self.s = CTX.wrap_socket(self.s)
+        self.read_for(0.5)
+
+    def send(self, line):
+        self.s.sendall((line + "\n").encode())
+
+    def read_until(self, substr, timeout=8):
+        deadline = time.time() + timeout
+        while substr not in self.buf and time.time() < deadline:
+            self.s.settimeout(max(0.1, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def read_for(self, seconds):
+        """Drain everything that arrives in a fixed window, for streams with no end marker."""
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.s.settimeout(max(0.05, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def close(self):
+        try: self.s.close()
+        except OSError: pass
+
+
+def register(user):
+    c = Client()
+    c.send("REGISTER %s %s" % (user, PW))
+    print("REGISTER %s -> %s" % (user, c.read_until("\n", 5).strip()))
+    c.close()
+
+
+def login(user, flags):
+    c = Client()
+    c.send("LOGIN %s %s 0 * TestClient\t0\t%s" % (user, PW, flags))
+    got = c.read_until("AGREEMENTEND", 10)
+    if "AGREEMENTEND" in got:
+        c.send("CONFIRMAGREEMENT")
+        got += c.read_until("LOGININFOEND", 10)
+    check("LOGININFOEND" in got, "%s should log in, got:\n%s" % (user, got))
+    c.login_text = got  # the battle list arrives during login, ahead of LOGININFOEND
+    return c
+
+
+def refusal(text):
+    """The MOVERELAYEDHOSTFAILED line in a stream, which arrives among unrelated traffic."""
+    for line in text.splitlines():
+        if line.startswith("MOVERELAYEDHOSTFAILED "):
+            return line.strip()
+    return ""
+
+
+def normalise(line, host_user, battle_id):
+    """Strip the parts that differ by construction: the host's name and the battle id."""
+    line = re.sub(r"__battle__\d+", "BCHAN", line.strip()).replace(host_user, "HOST")
+    return re.sub(r"(?<= )%s(?= |$)" % re.escape(battle_id), "BID", line)
+
+
+def hosted(host_user, flags, move):
+    """Open a battle, optionally trying to move it, and report what was seen."""
+    host = login(host_user, flags)
+    said = ""
+    if move:
+        host.send("RELAYEDHOST %s 30001" % RELAY_IP)
+        host.read_for(0.6)
+
+    host.send("OPENBATTLE 0 0 * 30001 8 4660 0 4660 spring\t105.0\tDeltaSiegeDry\tmove host test\tBA")
+    opened = host.read_for(1.5)
+    battle_id = None
+    for line in opened.splitlines():
+        if line.startswith("BATTLEOPENED "):
+            battle_id = line.split(" ")[1]
+    check(battle_id is not None, "OPENBATTLE should produce a BATTLEOPENED, got:\n%s" % opened)
+
+    if move:
+        host.send("MOVERELAYEDHOST %s 41234" % MOVED_IP)
+        said = refusal(host.read_for(1.0))
+
+    # a client logging in afterwards is told about the battle in the same BATTLEOPENED form,
+    # which is the line a joiner actually dials
+    watcher = login(WATCHER, "u sp r")
+    seen = ""
+    for line in watcher.login_text.splitlines():
+        if line.startswith("BATTLEOPENED "):
+            seen = line
+    watcher.close()
+    host.close()
+    time.sleep(0.5)  # let the server tear the battle down before the next one opens
+    return said, normalise(seen, host_user, battle_id or "")
+
+
+for user in (HOST_MOVE, HOST_PLAIN, IDLE, WATCHER):
+    register(user)
+print("waiting 3s for the delayed-registration window...")
+time.sleep(3)
+
+# a client hosting nothing at all, so the relay gate is reached before anything else
+idle = login(IDLE, "u sp r")
+idle.send("MOVERELAYEDHOST %s 41234" % MOVED_IP)
+idle_said = refusal(idle.read_for(1.0))
+idle.close()
+
+move_said, move_battle = hosted(HOST_MOVE, "u sp r", move=True)
+_, plain_battle = hosted(HOST_PLAIN, "u sp", move=False)
+print("MOVERELAYEDHOST while hosting nothing ->", idle_said)
+print("MOVERELAYEDHOST while hosting         ->", move_said)
+print("battle after a refused move ->", move_battle)
+print("battle nobody touched       ->", plain_battle)
+
+for said, who in ((idle_said, "a client hosting nothing"), (move_said, "a host")):
+    check(said != "", "a server with no relay should refuse %s a move" % who)
+    check(len(said.split(" ", 1)[-1]) > 10,
+          "the refusal to %s should carry a reason a person can read, got %r" % (who, said))
+
+check(move_battle.startswith("BATTLEOPENED "),
+      "the battle should have been advertised at all, got %r" % (move_battle,))
+check(MOVED_IP not in move_battle,
+      "a refused move must not reach the battle, got %r" % (move_battle,))
+check(move_battle.split(" ")[3] == "0",
+      "natType should still be 0, got %r" % (move_battle,))
+check(move_battle == plain_battle,
+      "a refused move must leave the battle exactly as it was:\n  %r\n  %r"
+      % (move_battle, plain_battle))
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/integration/relayedhostorderingtest.py
+++ b/tests/integration/relayedhostorderingtest.py
@@ -1,0 +1,134 @@
+"""
+End-to-end tier: RELAYEDHOSTFAILED is written before the answer to the OPENBATTLE behind it.
+
+A relay host sends RELAYEDHOST and OPENBATTLE back to back without waiting in between, so a
+refusal and a battle answer are both in flight at once. A client cannot act on the refusal
+until it knows whether the battle opened, which makes the order the two are written in a thing
+it depends on. The coilbox side reads the refusal only after the battle answer and asked for
+the ordering to be stated rather than assumed, on pull 36.
+
+This pins it. relayedhosttest.py covers what RELAYEDHOST does. This covers when the answer
+arrives relative to the battle, which that test cannot see because it reads between the sends.
+
+Both lines go out in one write here, which is what a client that is not waiting actually does.
+
+Run: activate the venv, then python3 tests/integration/relayedhostorderingtest.py
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import HOST, PORT
+import socket, ssl, hashlib, base64, time, sys
+
+raw_pw = "secretpw"
+PW = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+USER = "rhostorder"
+RELAY_IP = "185.199.108.153"  # a real public address: the documentation ranges are refused
+
+CTX = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)  # hosting requires TLS, cert is self-signed
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+def connect():
+    s = socket.create_connection((HOST, PORT))
+    s.settimeout(2)
+    try: s.recv(4096)          # greeting
+    except OSError: pass
+    s.sendall(b"STLS\n")
+    time.sleep(0.4)
+    try: s.recv(4096)          # OK
+    except OSError: pass
+    return CTX.wrap_socket(s)
+
+
+def read_for(s, seconds, stop=None):
+    """Drain for a fixed window, or until stop appears. Returns (text, chunk_count)."""
+    buf, chunks = "", 0
+    deadline = time.time() + seconds
+    while time.time() < deadline:
+        s.settimeout(max(0.05, deadline - time.time()))
+        try:
+            got = s.recv(65536)
+        except (socket.timeout, ssl.SSLWantReadError, OSError):
+            break
+        if not got:
+            break
+        buf += got.decode(errors="replace")
+        chunks += 1
+        if stop and stop in buf:
+            break
+    return buf, chunks
+
+
+s = connect()
+s.sendall(("REGISTER %s %s\n" % (USER, PW)).encode())
+print("REGISTER ->", read_for(s, 1.0)[0].strip())
+s.close()
+print("waiting 3s for the delayed-registration window...")
+time.sleep(3)
+
+s = connect()
+s.sendall(("LOGIN %s %s 0 * TestClient\t0\tu sp r\n" % (USER, PW)).encode())
+login, _ = read_for(s, 10, stop="LOGININFOEND")
+if "AGREEMENTEND" in login and "LOGININFOEND" not in login:
+    s.sendall(b"CONFIRMAGREEMENT\n")
+    more, _ = read_for(s, 10, stop="LOGININFOEND")
+    login += more
+check("LOGININFOEND" in login, "%s should log in, got:\n%s" % (USER, login))
+
+# one write, both lines, which is what a client that does not wait in between sends
+s.sendall(("RELAYEDHOST %s 30001\n" % RELAY_IP).encode()
+          + b"OPENBATTLE 0 0 * 30001 8 4660 0 4660 spring\t105.0\tDeltaSiegeDry\tordering\tBA\n")
+stream, chunks = read_for(s, 4, stop="REQUESTBATTLESTATUS")
+s.close()
+
+lines = [ln for ln in stream.splitlines() if ln.strip()]
+print("received in %d chunk(s):" % chunks)
+for ln in lines:
+    print("   ", ln)
+
+
+def index_of(prefix):
+    for i, ln in enumerate(lines):
+        if ln.startswith(prefix):
+            return i
+    return None
+
+
+refusal = index_of("RELAYEDHOSTFAILED ")
+check(refusal is not None,
+      "an unconfigured server should refuse RELAYEDHOST, got %r" % (lines,))
+
+# the battle answer is the ordinary pair, whichever way it went
+answer = index_of("OPENBATTLE ")
+if answer is None:
+    answer = index_of("OPENBATTLEFAILED ")
+check(answer is not None,
+      "the OPENBATTLE behind it should still be answered, got %r" % (lines,))
+
+if refusal is not None and answer is not None:
+    check(refusal < answer,
+          "RELAYEDHOSTFAILED should be written before the OPENBATTLE answer, got %r" % (lines,))
+
+# BATTLEOPENED is the line a client watches for, and it comes after the refusal too
+opened = index_of("BATTLEOPENED ")
+if refusal is not None and opened is not None:
+    check(refusal < opened,
+          "RELAYEDHOSTFAILED should be written before BATTLEOPENED, got %r" % (lines,))
+
+# and the refused address is not the one the battle was advertised at
+if opened is not None:
+    check(RELAY_IP not in lines[opened],
+          "a refused address must not reach the battle, got %r" % (lines[opened],))
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/integration/relayedhosttest.py
+++ b/tests/integration/relayedhosttest.py
@@ -1,0 +1,170 @@
+"""
+End-to-end tier: RELAYEDHOST (issue #32) against a server with no TURN relay configured.
+
+The shared test server boots without a server_turn.txt, which is the state every existing
+deployment is in, so the properties under test here are the negative ones. RELAYEDHOST is
+refused with a reason somebody can read, and the battle that follows is advertised exactly as
+it would have been if the line had never been sent. Two battles are opened, one by a host that
+sends RELAYEDHOST and one by a host that does not, and what an onlooker is told about each is
+compared line for line.
+
+The configured half, where the battle is advertised at the relay for every recipient, is
+covered in-process by tests/worker/relayedhostworkertest.py, which needs no server and cannot
+be disturbed by whatever config the operator has left in the repository root.
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import HOST, PORT
+import socket, ssl, hashlib, base64, re, time, sys
+
+raw_pw = "secretpw"
+PW = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+HOST_R = "rhosthostr"
+HOST_PLAIN = "rhosthostp"
+WATCHER = "rhostwatcher"
+RELAY_IP = "185.199.108.153"  # a real public address: the documentation ranges are refused
+
+# hosting requires TLS (in_OPENBATTLE), and the test server's certificate is self-signed
+CTX = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class Client:
+    def __init__(self):
+        self.s = socket.create_connection((HOST, PORT))
+        self.buf = ""
+        self.read_for(0.5)
+        self.send("STLS")
+        self.read_until("OK", 5)
+        self.s = CTX.wrap_socket(self.s)
+        self.read_for(0.5)
+
+    def send(self, line):
+        self.s.sendall((line + "\n").encode())
+
+    def read_until(self, substr, timeout=8):
+        deadline = time.time() + timeout
+        while substr not in self.buf and time.time() < deadline:
+            self.s.settimeout(max(0.1, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def read_for(self, seconds):
+        """Drain everything that arrives in a fixed window, for streams with no end marker."""
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.s.settimeout(max(0.05, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def close(self):
+        try: self.s.close()
+        except OSError: pass
+
+
+def register(user):
+    c = Client()
+    c.send("REGISTER %s %s" % (user, PW))
+    print("REGISTER %s -> %s" % (user, c.read_until("\n", 5).strip()))
+    c.close()
+
+
+def login(user, flags):
+    c = Client()
+    c.send("LOGIN %s %s 0 * TestClient\t0\t%s" % (user, PW, flags))
+    got = c.read_until("AGREEMENTEND", 10)
+    if "AGREEMENTEND" in got:
+        c.send("CONFIRMAGREEMENT")
+        got += c.read_until("LOGININFOEND", 10)
+    check("LOGININFOEND" in got, "%s should log in, got:\n%s" % (user, got))
+    c.login_text = got  # the battle list arrives during login, ahead of LOGININFOEND
+    return c
+
+
+def normalise(line, host_user, battle_id):
+    """Strip the parts that differ by construction: the host's name and the battle id."""
+    line = re.sub(r"__battle__\d+", "BCHAN", line.strip()).replace(host_user, "HOST")
+    return re.sub(r"(?<= )%s(?= |$)" % re.escape(battle_id), "BID", line)
+
+
+def hosted(host_user, flags, relayed):
+    """Open a battle, optionally naming a relay address first, and report what was seen."""
+    host = login(host_user, flags)
+    refusal = ""
+    if relayed:
+        host.send("RELAYEDHOST %s 30001" % RELAY_IP)
+        refusal = host.read_for(1.0).strip()
+
+    host.send("OPENBATTLE 0 0 * 30001 8 4660 0 4660 spring\t105.0\tDeltaSiegeDry\trelayed host test\tBA")
+    opened = host.read_for(1.5)
+    battle_id = None
+    for line in opened.splitlines():
+        if line.startswith("BATTLEOPENED "):
+            battle_id = line.split(" ")[1]
+    check(battle_id is not None, "OPENBATTLE should produce a BATTLEOPENED, got:\n%s" % opened)
+
+    # a client logging in afterwards is told about the battle in the same BATTLEOPENED form,
+    # which is the line a joiner actually dials
+    watcher = login(WATCHER, "u sp")
+    seen = ""
+    for line in watcher.login_text.splitlines():
+        if line.startswith("BATTLEOPENED "):
+            seen = line
+    watcher.close()
+    host.close()
+    time.sleep(0.5)  # let the server tear the battle down before the next one opens
+    return refusal, normalise(seen, host_user, battle_id or "")
+
+
+for user in (HOST_R, HOST_PLAIN, WATCHER):
+    register(user)
+print("waiting 3s for the delayed-registration window...")
+time.sleep(3)
+
+refusal, relay_battle = hosted(HOST_R, "u sp r", relayed=True)
+_, plain_battle = hosted(HOST_PLAIN, "u sp", relayed=False)
+print("RELAYEDHOST reply ->", refusal)
+print("battle after RELAYEDHOST ->", relay_battle)
+print("battle without one      ->", plain_battle)
+
+check(refusal.startswith("RELAYEDHOSTFAILED "),
+      "a server with no relay should refuse RELAYEDHOST, got %r" % (refusal,))
+check(len(refusal.split(" ", 1)[-1]) > 10,
+      "the refusal should carry a reason a person can read, got %r" % (refusal,))
+
+check(relay_battle.startswith("BATTLEOPENED "),
+      "the battle should have been advertised at all, got %r" % (relay_battle,))
+check(RELAY_IP not in relay_battle,
+      "a refused address must not reach the battle, got %r" % (relay_battle,))
+check(relay_battle.split(" ")[3] == "0",
+      "natType should still be 0, got %r" % (relay_battle,))
+check(relay_battle == plain_battle,
+      "a refused RELAYEDHOST must leave the battle exactly as it was:\n  %r\n  %r"
+      % (relay_battle, plain_battle))
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/integration/turnrelaytest.py
+++ b/tests/integration/turnrelaytest.py
@@ -1,0 +1,90 @@
+"""
+End-to-end tier: relay hosting against a server with no TURN relay configured.
+
+The shared test server boots without a server_turn.txt, which is the state every existing
+deployment is in. It must therefore leave 'r' out of COMPFLAGS, still accept 'r' from a
+client that sends it anyway, and answer TURNCREDENTIALS with a readable refusal rather than
+a compatibility complaint or a dropped line.
+
+The configured half of this is covered in-process by tests/worker/turnrelayworkertest.py,
+which needs no server and cannot be disturbed by whatever config the operator has left in
+the repository root.
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import HOST, PORT
+import socket, hashlib, base64, time, sys
+
+user = "relaynoturn"
+raw_pw = "secretpw"
+pw = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+def recv_until(s, substr, timeout=5):
+    s.settimeout(timeout)
+    buf = b""
+    try:
+        while substr.encode() not in buf:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+    except socket.timeout:
+        pass
+    return buf.decode(errors="replace")
+
+s = socket.create_connection((HOST, PORT))
+recv_until(s, "\n")
+
+s.sendall(("REGISTER %s %s\n" % (user, pw)).encode())
+print("REGISTER ->", recv_until(s, "\n").strip())
+
+print("waiting 3s for the delayed-registration window...")
+time.sleep(3)
+
+# log in advertising 'r' alongside the mandatory flags. A server with no relay must not
+# complain about it: the flag is known everywhere, it is only advertised conditionally.
+s.sendall(("LOGIN %s %s 0 * TestClient\t0\tu sp r\n" % (user, pw)).encode())
+login = recv_until(s, "AGREEMENTEND")
+if "AGREEMENTEND" in login:
+    s.sendall(b"CONFIRMAGREEMENT\n")
+    login += recv_until(s, "LOGININFOEND")
+check("LOGININFOEND" in login, "login should complete, got:\n%s" % login)
+check("compatibility errors" not in login,
+      "sending 'r' to a relay-less server must not raise a compatibility warning, got:\n%s" % login)
+
+s.sendall(b"LISTCOMPFLAGS\n")
+compflags = ""
+for line in recv_until(s, "COMPFLAGS").splitlines():
+    if line.startswith("COMPFLAGS"):
+        compflags = line
+print("LISTCOMPFLAGS ->", compflags)
+flags = compflags.split()[1:]
+check(compflags != "", "the server should answer LISTCOMPFLAGS")
+check("r" not in flags, "'r' must not be advertised with no relay configured, got %r" % (flags,))
+check("u" in flags and "sp" in flags, "the other flags should still be advertised, got %r" % (flags,))
+
+s.sendall(b"TURNCREDENTIALS\n")
+reply = ""
+for line in recv_until(s, "TURNCREDENTIALS").splitlines():
+    if line.startswith("TURNCREDENTIALS"):
+        reply = line
+print("TURNCREDENTIALS ->", reply)
+check(reply.startswith("TURNCREDENTIALSFAILED "),
+      "a relay-less server should refuse cleanly, got %r" % (reply,))
+check(len(reply.split(" ", 1)[1].strip()) > 0 if " " in reply else False,
+      "the refusal should carry a reason, got %r" % (reply,))
+check("failed. Unknown command" not in reply and "Insufficient rights" not in reply,
+      "TURNCREDENTIALS should be a known command available to a logged-in user, got %r" % (reply,))
+
+s.close()
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/worker/joineraddressworkertest.py
+++ b/tests/worker/joineraddressworkertest.py
@@ -1,0 +1,180 @@
+"""
+Worker-unit test for joiner addresses (issue #28): the CLIENTIP line a relay host is sent
+when somebody joins its battle. Runs the real Battle.joinBattle in-process against fake
+clients, no server and no DB needed.
+
+The property that matters most is the negative one. A host that knows nothing about relays
+must see exactly the conversation it saw before, so every case here compares the host's whole
+received stream against a baseline host, rather than only asserting that CLIENTIP is absent.
+
+Run: activate the venv, then python3 tests/worker/joineraddressworkertest.py
+"""
+import os as _os, sys as _sys
+_ROOT = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir))
+_sys.path[:0] = [_ROOT, _os.path.join(_ROOT, "protocol"),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+import sys
+
+from protocol import Protocol as ProtocolModule
+from protocol.Battle import Battle
+
+PROXY = "10.0.0.1"
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class FakeRoot:
+    def __init__(self, relay=True):
+        self.turn_uri = "turn:relay.example.org:3478" if relay else None
+        self.turn_secret = "a_long_random_string" if relay else None
+        self.trusted_proxies = set([PROXY])
+        self.sessions = {}
+        self.broadcasts = []
+        self.SayHooks = None
+        self.protocol = ProtocolModule.Protocol(self)
+    def turn_enabled(self):
+        return bool(self.turn_uri and self.turn_secret)
+    def clientFromSession(self, session_id):
+        return self.sessions.get(session_id)
+    def clientFromID(self, user_id, fromdb=False):
+        return None
+    def broadcast(self, message, chan=None, ignore=set(), state=None, flag=None, not_flag=None):
+        self.broadcasts.append(message)
+    def getUserDB(self): pass
+    def getVerificationDB(self): pass
+    def getBanDB(self): pass
+    def getContentDB(self): pass
+
+
+class FakeClient:
+    _next_session = 1
+    def __init__(self, root, username, compat=("u", "sp"), ip="203.0.113.7", local_ip=None):
+        self.sent = []
+        self.username = username
+        self.compat = set(compat)
+        self.ip_address = ip
+        self.local_ip = local_ip if local_ip else ip
+        self.session_id = FakeClient._next_session
+        FakeClient._next_session += 1
+        self.static = True  # skips Channel.recordUse, which wants a db
+        self.channels = set()
+        self.battle_bots = {}
+        self.scriptPassword = None
+        self.current_battle = None
+        self.hostport = None
+        self.udpport = None
+        self.battlestatus = {'ready':'0', 'id':'0000', 'ally':'0000', 'mode':'0',
+                             'sync':'00', 'side':'00', 'handicap':'0000000'}
+        self.teamcolor = '0'
+        root.sessions[self.session_id] = self
+    def Send(self, data, command=None):
+        self.sent.append(data)
+
+
+def open_battle(root, host):
+    battle = Battle(root, "__battle__0")
+    battle.battle_id = 0
+    battle.hashcode = 0
+    battle.natType = 0
+    battle.host = host.session_id
+    battle.joinBattle(host)
+    host.sent = []
+    return battle
+
+
+def join(root, battle, joiner):
+    """Join a battle and hand back what the host received during that join."""
+    host = root.clientFromSession(battle.host)
+    before = len(host.sent)
+    battle.joinBattle(joiner)
+    return host.sent[before:]
+
+
+def clientips(lines):
+    return [line for line in lines if line.split(" ")[0] == "CLIENTIP"]
+
+
+# --- a relay host is told each joiner's address ------------------------------------
+root = FakeRoot()
+host = FakeClient(root, "relayhost", compat=("u", "sp", "r"))
+battle = open_battle(root, host)
+
+first = join(root, battle, FakeClient(root, "joiner1"))
+check(clientips(first) == ["CLIENTIP joiner1 203.0.113.7"],
+      "a relay host should be told the joiner's address, got %r" % (first,))
+
+# ahead of JOINEDBATTLE: the host has the address in hand by the time it hears about the join
+if clientips(first):
+    joined = [i for i, line in enumerate(first) if line.startswith("JOINEDBATTLE ")]
+    check(joined and first.index(clientips(first)[0]) < joined[0],
+          "CLIENTIP should arrive before JOINEDBATTLE, got %r" % (first,))
+
+# a second joiner, mid-game or spectating, is the same case: joins run through one path
+second = join(root, battle, FakeClient(root, "joiner2", ip="203.0.113.9"))
+check(clientips(second) == ["CLIENTIP joiner2 203.0.113.9"],
+      "every later joiner should get the same treatment, got %r" % (second,))
+
+# the host's own join says nothing about the host
+solo_root = FakeRoot()
+solo_host = FakeClient(solo_root, "lonehost", compat=("u", "sp", "r"))
+solo = Battle(solo_root, "__battle__1")
+solo.battle_id = 1
+solo.hashcode = 0
+solo.natType = 0
+solo.host = solo_host.session_id
+solo.joinBattle(solo_host)
+check(clientips(solo_host.sent) == [],
+      "a host joining its own battle should not be sent its own address, got %r" % (solo_host.sent,))
+
+
+# --- the address is the public one, not the LAN one -------------------------------
+root = FakeRoot()
+host = FakeClient(root, "relayhost", compat=("u", "sp", "r"))
+battle = open_battle(root, host)
+
+lan = join(root, battle, FakeClient(root, "lanjoiner", ip="198.51.100.4", local_ip="192.168.1.50"))
+check(clientips(lan) == ["CLIENTIP lanjoiner 198.51.100.4"],
+      "the joiner's public address should be sent, not local_ip, got %r" % (lan,))
+
+# behind a trusted proxy the socket address is the proxy's, and the real one is local_ip
+proxied = join(root, battle, FakeClient(root, "proxiedjoiner", ip=PROXY, local_ip="198.51.100.9"))
+check(clientips(proxied) == ["CLIENTIP proxiedjoiner 198.51.100.9"],
+      "behind a trusted proxy the joiner's own address should be sent, got %r" % (proxied,))
+
+
+# --- nobody else's conversation changes -------------------------------------------
+# The baseline is a host with no 'r' on a server with no relay, which is every deployment
+# before this change. Compare the whole stream, not just the absence of CLIENTIP.
+def conversation(relay, host_compat):
+    root = FakeRoot(relay=relay)
+    FakeClient._next_session = 1  # session ids appear in nothing sent, but keep runs identical
+    host = FakeClient(root, "host", compat=host_compat)
+    battle = open_battle(root, host)
+    return join(root, battle, FakeClient(root, "joiner1"))
+
+baseline = conversation(relay=False, host_compat=("u", "sp"))
+check(clientips(baseline) == [], "the baseline host should get no CLIENTIP, got %r" % (baseline,))
+
+no_flag = conversation(relay=True, host_compat=("u", "sp"))
+check(no_flag == baseline,
+      "a host that did not ask for relay support should see an unchanged conversation:\n  %r\n  %r"
+      % (no_flag, baseline))
+
+no_relay = conversation(relay=False, host_compat=("u", "sp", "r"))
+check(no_relay == baseline,
+      "a server with no relay should send nothing new even to a relay host:\n  %r\n  %r"
+      % (no_relay, baseline))
+
+relayed = conversation(relay=True, host_compat=("u", "sp", "r"))
+check(relayed == ["CLIENTIP joiner1 203.0.113.7"] + baseline,
+      "a relay host's conversation should be the baseline plus one line, got:\n  %r\n  %r"
+      % (relayed, baseline))
+
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("PASS: CLIENTIP reaches a relay host with the joiner's public address, and nobody else's conversation changes")

--- a/tests/worker/moverelayedhostworkertest.py
+++ b/tests/worker/moverelayedhostworkertest.py
@@ -1,0 +1,380 @@
+"""
+Worker-unit test for MOVERELAYEDHOST (issue #43): moving an open battle to a rebuilt relay
+allocation. Runs the real in_MOVERELAYEDHOST, in_RELAYEDHOST, in_OPENBATTLE and
+client_AddBattle in-process against fakes, no server and no DB needed.
+
+Three properties matter.
+
+The port moves with the address. A rebuilt allocation lands on a new address *and* a new
+port, and MOVERELAYEDHOST is the only line carrying either, so a move that updated the
+address alone would leave the battle exactly as unreachable as it was. Every assertion here
+checks both fields.
+
+Only the host moves a battle, and only a relayed one. A spectator sitting in somebody else's
+battle must not be able to send everybody in it to an address of its choosing, and a battle
+opened at a working direct address must not be converted, because everyone already holding
+that address would be stranded on it.
+
+Nobody else's conversation changes. BATTLEHOSTMOVED goes only to clients that asked for relay
+support at login, and a battle nobody moves is advertised exactly as it was.
+
+Run: activate the venv, then python3 tests/worker/moverelayedhostworkertest.py
+"""
+import os as _os, sys as _sys
+_ROOT = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir))
+_sys.path[:0] = [_ROOT, _os.path.join(_ROOT, "protocol"),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+import sys
+
+from protocol import Protocol as ProtocolModule
+
+# Real public addresses, because the documentation ranges are refused along with everything
+# else nobody can route to. OPEN_V4 is where the battle opens, MOVED_V4 is the rebuilt
+# allocation it moves to.
+OPEN_V4 = "185.199.108.153"
+MOVED_V4 = "151.101.1.140"
+MOVED_V6 = "2606:4700:4700::1111"
+LOBBY_IP = "192.0.2.1"
+LOBBY_LAN = "10.0.0.2"
+HOST_WAN = "81.2.69.142"
+HOST_LAN = "192.168.1.10"
+OUTSIDER = "31.13.72.36"
+
+OPEN_PORT = "30001"
+MOVED_PORT = "41234"
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class FakeChannelDB:
+    """Battles are never registered channels, which is all LEAVEBATTLE asks about."""
+    @staticmethod
+    def registered(channel):
+        return False
+
+
+class FakeSayHooks:
+    @staticmethod
+    def hook_OPENBATTLE(protocol, client, title):
+        return title
+
+
+class FakeRoot:
+    def __init__(self, relay=True):
+        self.turn_uri = "turn:relay.example.org:3478" if relay else None
+        self.turn_secret = "a_long_random_string" if relay else None
+        self.online_ip = LOBBY_IP
+        self.local_ip = LOBBY_LAN
+        self.trusted_proxies = set()
+        self.channels = {}
+        self.battles = {}
+        self.usernames = {}
+        self.sessions = {}
+        self.nextbattle = 0
+        self.broadcasts = []
+        self.SayHooks = FakeSayHooks
+        self.channeldb = FakeChannelDB
+        self.protocol = ProtocolModule.Protocol(self)
+    def turn_enabled(self):
+        return bool(self.turn_uri and self.turn_secret)
+    def clientFromSession(self, session_id):
+        return self.sessions.get(session_id)
+    def clientFromID(self, user_id, fromdb=False):
+        return None
+    def broadcast(self, message, chan=None, ignore=set(), state=None, flag=None, not_flag=None):
+        self.broadcasts.append(message)
+    def broadcast_battle(self, message, battle_id, ignore=None):
+        self.broadcasts.append(message)
+    def getUserDB(self): pass
+    def getVerificationDB(self): pass
+    def getBanDB(self): pass
+    def getContentDB(self): pass
+
+
+class FakeClient:
+    _next_session = 1
+    def __init__(self, root, username, compat=("u", "sp"), ip=HOST_WAN, local_ip=None):
+        self.sent = []
+        self.username = username
+        self.compat = set(compat)
+        self.ip_address = ip
+        self.local_ip = local_ip if local_ip else ip
+        self.user_id = FakeClient._next_session
+        self.session_id = FakeClient._next_session
+        FakeClient._next_session += 1
+        self.static = True  # skips Channel.recordUse, which wants a db
+        self.TLS = True     # in_OPENBATTLE refuses to host without it
+        self.bot = False
+        self.channels = set()
+        self.battle_bots = {}
+        self.scriptPassword = None
+        self.current_battle = None
+        self.pending_battle = None
+        self.relayed_host_ip = None
+        self.hostport = None
+        self.udpport = None
+        self.ignored = {}
+        self.battlestatus = {'ready':'0', 'id':'0000', 'ally':'0000', 'mode':'0',
+                             'sync':'00', 'side':'00', 'handicap':'0000000'}
+        self.teamcolor = '0'
+        root.sessions[self.session_id] = self
+        root.usernames[username] = self
+    def Send(self, data, command=None):
+        self.sent.append(data)
+    def SendBattle(self, battle, data):
+        self.sent.append(data)
+
+
+def reply(client, fn, *args):
+    """Run a command and hand back its refusal, or "" when it was accepted.
+
+    A move that succeeds sends the host its own BATTLEHOSTMOVED, so the refusal is the
+    *FAILED line rather than simply the first thing the sender was sent.
+    """
+    before = len(client.sent)
+    fn(*args)
+    for line in client.sent[before:]:
+        if line.split(" ")[0].endswith("FAILED"):
+            return line
+    return ""
+
+
+def relayedhost(root, client, ip, port=OPEN_PORT):
+    return reply(client, root.protocol.in_RELAYEDHOST, client, ip, port)
+
+
+def moverelayedhost(root, client, ip, port=MOVED_PORT):
+    return reply(client, root.protocol.in_MOVERELAYEDHOST, client, ip, port)
+
+
+def openbattle(root, host, port=OPEN_PORT, title="relay move test"):
+    root.protocol.in_OPENBATTLE(host, "0", "0", "*", port, "8", "4660", "0", "4660",
+                                "spring\t105.0\tDeltaSiegeDry\t%s\tBA" % title)
+    return root.battles[host.current_battle]
+
+
+def advertised_to(root, client, battle):
+    """The BATTLEOPENED a client logging in now would be sent for this battle.
+
+    client_AddBattle is the one place the address and port are worked out, and login
+    (_login_finish_now) and broadcast_AddBattle both go through it, so this is what a
+    late arrival is actually told.
+    """
+    return root.protocol.client_AddBattle(client, battle)
+
+
+def field(line, n):
+    return line.split(" ")[n] if line else ""
+
+
+def address_of(line):
+    return field(line, 5)
+
+
+def port_of(line):
+    return field(line, 6)
+
+
+def moved_lines(client):
+    return [line for line in client.sent if line.startswith("BATTLEHOSTMOVED ")]
+
+
+def relayed_battle(host_compat=("u", "sp", "r")):
+    """A relay host with an open battle, an onlooker with 'r' and one without."""
+    FakeClient._next_session = 1  # the battle channel is named after the host's account id
+    root = FakeRoot()
+    host = FakeClient(root, "movehost", compat=host_compat)
+    watcher = FakeClient(root, "watcher_r", compat=("u", "sp", "r"), ip=OUTSIDER)
+    plain = FakeClient(root, "watcher_plain", compat=("u", "sp"), ip=OUTSIDER)
+    relayedhost(root, host, OPEN_V4)
+    battle = openbattle(root, host)
+    for c in (host, watcher, plain):
+        c.sent = []
+    return root, host, watcher, plain, battle
+
+
+# --- the happy path: address and port both move -----------------------------------
+root, host, watcher, plain, battle = relayed_battle()
+opened = advertised_to(root, watcher, battle)
+check(address_of(opened) == OPEN_V4,
+      "the battle should open at the relay, got %r" % (opened,))
+check(port_of(opened) == OPEN_PORT,
+      "the battle should open at the OPENBATTLE port, got %r" % (opened,))
+
+check(moverelayedhost(root, host, MOVED_V4) == "",
+      "a public address should be accepted in silence, got %r" % (host.sent,))
+
+after = advertised_to(root, watcher, battle)
+check(address_of(after) == MOVED_V4,
+      "a client arriving after the move should be told the new address, got %r" % (after,))
+# the trap: a move that only changed the address would leave the battle on the old port,
+# which is exactly as unreachable as the old address was
+check(port_of(after) == MOVED_PORT,
+      "a client arriving after the move should be told the new port, got %r" % (after,))
+check(field(after, 3) == "0",
+      "natType should still be 0 after a move, got %r" % (after,))
+
+# everything else about the battle is the line it was
+def without_address(line):
+    fields = line.split(" ")
+    fields[5] = "IP"
+    fields[6] = "PORT"
+    return " ".join(fields)
+
+check(without_address(after) == without_address(opened),
+      "only the address and port should differ across a move:\n  %r\n  %r" % (opened, after))
+
+# a joiner behind the same NAT as the host is told the relay too, as it was at OPENBATTLE
+samewan = FakeClient(root, "samewan", compat=("u", "sp"), ip=HOST_WAN, local_ip="192.168.1.11")
+same = advertised_to(root, samewan, battle)
+check(address_of(same) == MOVED_V4 and port_of(same) == MOVED_PORT,
+      "a same-WAN joiner should be told the moved relay pair, got %r" % (same,))
+
+
+# --- who is told, and what ---------------------------------------------------------
+check(moved_lines(watcher) == ["BATTLEHOSTMOVED %s %s %s" % (battle.battle_id, MOVED_V4, MOVED_PORT)],
+      "an 'r' client already holding the battle should be told it moved, got %r" % (watcher.sent,))
+check(moved_lines(host) == ["BATTLEHOSTMOVED %s %s %s" % (battle.battle_id, MOVED_V4, MOVED_PORT)],
+      "the host should get its own move back as the acknowledgement, got %r" % (host.sent,))
+check(plain.sent == [],
+      "a client that did not ask for relay support should hear nothing, got %r" % (plain.sent,))
+
+
+# --- IPv6 moves too, in canonical form ---------------------------------------------
+root, host, watcher, plain, battle = relayed_battle()
+check(moverelayedhost(root, host, "2606:4700:4700:0000:0000:0000:0000:1111", "3478") == "",
+      "an expanded IPv6 address should be accepted, got %r" % (host.sent,))
+after = advertised_to(root, watcher, battle)
+check(address_of(after) == MOVED_V6 and port_of(after) == "3478",
+      "IPv6 should move canonicalised, got %r" % (after,))
+
+
+# --- only the host moves it --------------------------------------------------------
+root, host, watcher, plain, battle = relayed_battle()
+joiner = FakeClient(root, "joiner", compat=("u", "sp", "r"), ip=OUTSIDER)
+battle.joinBattle(joiner)
+joiner.sent = []
+reply_text = moverelayedhost(root, joiner, MOVED_V4)
+check(reply_text.startswith("MOVERELAYEDHOSTFAILED "),
+      "a non-host sitting in the battle should be refused, got %r" % (reply_text,))
+check(battle.relayed_ip == OPEN_V4 and str(battle.port) == OPEN_PORT,
+      "a refused non-host must not move the battle, got %r:%r" % (battle.relayed_ip, battle.port))
+check(moved_lines(watcher) == [],
+      "a refused move must announce nothing, got %r" % (watcher.sent,))
+
+# and neither does somebody in no battle at all
+outsider = FakeClient(root, "nobattle", compat=("u", "sp", "r"), ip=OUTSIDER)
+reply_text = moverelayedhost(root, outsider, MOVED_V4)
+check(reply_text.startswith("MOVERELAYEDHOSTFAILED "),
+      "a client hosting nothing should be refused, got %r" % (reply_text,))
+
+
+# --- a battle that was never relayed is not converted -------------------------------
+FakeClient._next_session = 1
+root = FakeRoot()
+direct_host = FakeClient(root, "directhost", compat=("u", "sp", "r"))
+watcher = FakeClient(root, "watcher_r", compat=("u", "sp", "r"), ip=OUTSIDER)
+battle = openbattle(root, direct_host)
+before = advertised_to(root, watcher, battle)
+direct_host.sent = []
+watcher.sent = []
+reply_text = moverelayedhost(root, direct_host, MOVED_V4)
+check(reply_text.startswith("MOVERELAYEDHOSTFAILED "),
+      "a direct battle should not be convertible to a relayed one, got %r" % (reply_text,))
+check(battle.relayed_ip is None,
+      "a refused conversion must leave the battle direct, got %r" % (battle.relayed_ip,))
+check(advertised_to(root, watcher, battle) == before,
+      "a refused conversion must leave the battle exactly as it was:\n  %r\n  %r"
+      % (before, advertised_to(root, watcher, battle)))
+check(moved_lines(watcher) == [],
+      "a refused conversion must announce nothing, got %r" % (watcher.sent,))
+
+
+# --- addresses and ports that are refused -------------------------------------------
+refusals = [
+    ("127.0.0.1", "loopback"),
+    ("::1", "IPv6 loopback"),
+    ("10.0.0.5", "a private range"),
+    ("192.168.1.10", "a private range"),
+    ("172.16.3.4", "a private range"),
+    ("169.254.7.7", "link-local"),
+    ("100.64.0.1", "carrier-grade NAT"),
+    ("0.0.0.0", "the unspecified address"),
+    ("224.0.0.1", "multicast"),
+    ("fd00::1", "an IPv6 unique-local address"),
+    ("fe80::1", "an IPv6 link-local address"),
+    ("2001:db8::1", "the IPv6 documentation range"),
+    (LOBBY_IP, "the lobby server's own address"),
+    (LOBBY_LAN, "the lobby server's LAN address"),
+    ("not.an.address", "a string that is not an address"),
+    ("", "an empty address"),
+]
+for bad, why in refusals:
+    root, host, watcher, plain, battle = relayed_battle()
+    reply_text = moverelayedhost(root, host, bad)
+    check(reply_text.startswith("MOVERELAYEDHOSTFAILED "),
+          "%s (%r) should be refused with a reason, got %r" % (why, bad, reply_text))
+    check(len(reply_text.split(" ", 1)[-1]) > 10,
+          "%s should be refused with something a person can read, got %r" % (why, reply_text))
+    check(battle.relayed_ip == OPEN_V4 and str(battle.port) == OPEN_PORT,
+          "%s must leave the battle where it was, got %r:%r" % (why, battle.relayed_ip, battle.port))
+    check(moved_lines(watcher) == [], "%s must announce nothing, got %r" % (why, watcher.sent))
+
+for bad_port, why in [("0", "port zero"), ("65536", "a port past the top of the range"),
+                      ("-1", "a negative port"), ("relay", "a port that is not a number")]:
+    root, host, watcher, plain, battle = relayed_battle()
+    reply_text = moverelayedhost(root, host, MOVED_V4, port=bad_port)
+    check(reply_text.startswith("MOVERELAYEDHOSTFAILED "),
+          "%s should be refused, got %r" % (why, reply_text))
+    check(battle.relayed_ip == OPEN_V4 and str(battle.port) == OPEN_PORT,
+          "%s must leave the battle where it was, got %r:%r" % (why, battle.relayed_ip, battle.port))
+
+
+# --- the two gates every relay command has ------------------------------------------
+root, host, watcher, plain, battle = relayed_battle(host_compat=("u", "sp"))
+# a host with no 'r' cannot have opened a relayed battle in practice, but the flag is
+# checked on its own so that dropping it mid-session cannot be used to move anything
+reply_text = moverelayedhost(root, host, MOVED_V4)
+check(reply_text.startswith("MOVERELAYEDHOSTFAILED "),
+      "a client without the 'r' flag should be refused, got %r" % (reply_text,))
+
+FakeClient._next_session = 1
+norelay = FakeRoot(relay=False)
+norelay_host = FakeClient(norelay, "norelayhost", compat=("u", "sp", "r"))
+battle = openbattle(norelay, norelay_host)
+norelay_host.sent = []
+reply_text = moverelayedhost(norelay, norelay_host, MOVED_V4)
+check(reply_text.startswith("MOVERELAYEDHOSTFAILED "),
+      "a server with no relay should refuse a move, got %r" % (reply_text,))
+check(battle.relayed_ip is None,
+      "a refused move on a relayless server must change nothing, got %r" % (battle.relayed_ip,))
+
+
+# --- the sequence a single overloaded command would have broken ----------------------
+# A relay host reopening its battle sends RELAYEDHOST while the old one is still open.
+# in_OPENBATTLE reads the staged address before the in_LEAVEBATTLE that closes the old
+# battle, so "the sender is hosting" does not tell a move apart from a re-host. Keeping
+# MOVERELAYEDHOST separate leaves this working.
+root, host, watcher, plain, battle = relayed_battle()
+first_id = battle.battle_id
+relayedhost(root, host, MOVED_V4, port=MOVED_PORT)
+check(battle.relayed_ip == OPEN_V4 and str(battle.port) == OPEN_PORT,
+      "RELAYEDHOST must not move the battle already open, got %r:%r"
+      % (battle.relayed_ip, battle.port))
+second = openbattle(root, host, port=MOVED_PORT, title="reopened")
+check(second.battle_id != first_id, "the reopen should be a new battle")
+reopened = advertised_to(root, watcher, second)
+check(address_of(reopened) == MOVED_V4 and port_of(reopened) == MOVED_PORT,
+      "the reopened battle should be advertised at the new relay, got %r" % (reopened,))
+check(moved_lines(watcher) == [],
+      "reopening a battle is not a move and must announce none, got %r" % (watcher.sent,))
+
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("PASS: MOVERELAYEDHOST moves an open relayed battle's address and port together, "
+      "refuses everybody but its host, and leaves every other client's conversation alone")

--- a/tests/worker/relayedhostworkertest.py
+++ b/tests/worker/relayedhostworkertest.py
@@ -1,0 +1,308 @@
+"""
+Worker-unit test for RELAYEDHOST (issue #32): the address a relay host names for its battle.
+Runs the real in_RELAYEDHOST, in_OPENBATTLE and client_AddBattle in-process against fakes, no
+server and no DB needed.
+
+Two properties matter. A relayed battle is advertised at the relay for every recipient, which
+means the same-WAN-IP branch of client_AddBattle has to go as well as the other two: two
+players behind one NAT reach a relayed battle through the relay, not across their own LAN. And
+a battle nobody named an address for is advertised exactly as it was before, so every case
+here is run twice, once with RELAYEDHOST and once without, and the two are compared.
+
+Run: activate the venv, then python3 tests/worker/relayedhostworkertest.py
+"""
+import os as _os, sys as _sys
+_ROOT = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir))
+_sys.path[:0] = [_ROOT, _os.path.join(_ROOT, "protocol"),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+import sys
+
+from protocol import Protocol as ProtocolModule
+
+# A relay allocation is on the public internet, and the documentation ranges (203.0.113.0/24,
+# 198.51.100.0/24, 2001:db8::/32) are not, so they are refused along with everything else
+# nobody can route to. That leaves real addresses as the only way to write these tests.
+RELAY_V4 = "185.199.108.153"
+RELAY_V6 = "2606:4700:4700::1111"
+LOBBY_IP = "192.0.2.1"        # only ever compared against, never advertised
+LOBBY_LAN = "10.0.0.2"
+HOST_WAN = "81.2.69.142"
+HOST_LAN = "192.168.1.10"
+OUTSIDER = "31.13.72.36"
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class FakeChannelDB:
+    """Battles are never registered channels, which is all LEAVEBATTLE asks about."""
+    @staticmethod
+    def registered(channel):
+        return False
+
+
+class FakeSayHooks:
+    @staticmethod
+    def hook_OPENBATTLE(protocol, client, title):
+        return title
+
+
+class FakeRoot:
+    def __init__(self, relay=True):
+        self.turn_uri = "turn:relay.example.org:3478" if relay else None
+        self.turn_secret = "a_long_random_string" if relay else None
+        self.online_ip = LOBBY_IP
+        self.local_ip = LOBBY_LAN
+        self.trusted_proxies = set()
+        self.channels = {}
+        self.battles = {}
+        self.usernames = {}
+        self.sessions = {}
+        self.nextbattle = 0
+        self.broadcasts = []
+        self.SayHooks = FakeSayHooks
+        self.channeldb = FakeChannelDB
+        self.protocol = ProtocolModule.Protocol(self)
+    def turn_enabled(self):
+        return bool(self.turn_uri and self.turn_secret)
+    def clientFromSession(self, session_id):
+        return self.sessions.get(session_id)
+    def clientFromID(self, user_id, fromdb=False):
+        return None
+    def broadcast(self, message, chan=None, ignore=set(), state=None, flag=None, not_flag=None):
+        self.broadcasts.append(message)
+    def getUserDB(self): pass
+    def getVerificationDB(self): pass
+    def getBanDB(self): pass
+    def getContentDB(self): pass
+
+
+class FakeClient:
+    _next_session = 1
+    def __init__(self, root, username, compat=("u", "sp"), ip=HOST_WAN, local_ip=None):
+        self.sent = []
+        self.username = username
+        self.compat = set(compat)
+        self.ip_address = ip
+        self.local_ip = local_ip if local_ip else ip
+        self.user_id = FakeClient._next_session
+        self.session_id = FakeClient._next_session
+        FakeClient._next_session += 1
+        self.static = True  # skips Channel.recordUse, which wants a db
+        self.TLS = True     # in_OPENBATTLE refuses to host without it
+        self.bot = False
+        self.channels = set()
+        self.battle_bots = {}
+        self.scriptPassword = None
+        self.current_battle = None
+        self.pending_battle = None
+        self.relayed_host_ip = None
+        self.hostport = None
+        self.udpport = None
+        self.battlestatus = {'ready':'0', 'id':'0000', 'ally':'0000', 'mode':'0',
+                             'sync':'00', 'side':'00', 'handicap':'0000000'}
+        self.teamcolor = '0'
+        root.sessions[self.session_id] = self
+        root.usernames[username] = self
+    def Send(self, data, command=None):
+        self.sent.append(data)
+
+
+def relayedhost(root, client, ip, port="30001"):
+    """Send RELAYEDHOST and hand back the reply, or "" when it was accepted in silence."""
+    before = len(client.sent)
+    root.protocol.in_RELAYEDHOST(client, ip, port)
+    after = client.sent[before:]
+    return after[0] if after else ""
+
+
+def openbattle(root, host, title="relay test"):
+    root.protocol.in_OPENBATTLE(host, "0", "0", "*", "30001", "8", "4660", "0", "4660",
+                                "spring\t105.0\tDeltaSiegeDry\t%s\tBA" % title)
+
+
+def advertised(client):
+    for line in reversed(client.sent):
+        if line.startswith("BATTLEOPENED "):
+            return line
+    return ""
+
+
+def battle_address(line):
+    """The <ip> field of a BATTLEOPENED, which is field 5."""
+    return line.split(" ")[5] if line else ""
+
+
+# --- what RELAYEDHOST accepts -----------------------------------------------------
+root = FakeRoot()
+host = FakeClient(root, "relayhost", compat=("u", "sp", "r"))
+
+check(relayedhost(root, host, RELAY_V4) == "",
+      "a public IPv4 relay address should be accepted in silence, got %r" % (host.sent,))
+check(host.relayed_host_ip == RELAY_V4,
+      "the address should be held against the client, got %r" % (host.relayed_host_ip,))
+
+check(relayedhost(root, host, RELAY_V6) == "",
+      "a public IPv6 relay address should be accepted, got %r" % (host.sent,))
+check(host.relayed_host_ip == RELAY_V6,
+      "IPv6 should be held as sent, got %r" % (host.relayed_host_ip,))
+
+# one address, one spelling: what reaches a joining client is the canonical form
+relayedhost(root, host, "2606:4700:4700:0000:0000:0000:0000:1111")
+check(host.relayed_host_ip == RELAY_V6,
+      "an expanded IPv6 address should be canonicalised, got %r" % (host.relayed_host_ip,))
+
+
+# --- what it refuses --------------------------------------------------------------
+refusals = [
+    ("127.0.0.1", "loopback"),
+    ("::1", "IPv6 loopback"),
+    ("10.0.0.5", "a private range"),
+    ("192.168.1.10", "a private range"),
+    ("172.16.3.4", "a private range"),
+    ("169.254.7.7", "link-local"),
+    ("100.64.0.1", "carrier-grade NAT"),
+    ("0.0.0.0", "the unspecified address"),
+    ("224.0.0.1", "multicast"),
+    ("fd00::1", "an IPv6 unique-local address"),
+    ("fe80::1", "an IPv6 link-local address"),
+    ("ff02::1", "IPv6 multicast"),
+    ("2001:db8::1", "the IPv6 documentation range"),
+    (LOBBY_IP, "the lobby server's own address"),
+    (LOBBY_LAN, "the lobby server's LAN address"),
+    ("not.an.address", "a string that is not an address"),
+    ("010.0.0.1", "an octal-looking address"),
+    ("", "an empty address"),
+]
+for bad, why in refusals:
+    victim = FakeClient(root, "refused_%s" % why.replace(" ", "_"), compat=("u", "sp", "r"))
+    reply = relayedhost(root, victim, bad)
+    check(reply.startswith("RELAYEDHOSTFAILED "),
+          "%s (%r) should be refused with a reason, got %r" % (why, bad, reply))
+    check(len(reply.split(" ", 1)[-1]) > 10,
+          "%s should be refused with something a person can read, got %r" % (why, reply))
+    check(victim.relayed_host_ip is None,
+          "%s should leave no address behind, got %r" % (why, victim.relayed_host_ip))
+
+for bad_port, why in [("0", "port zero"), ("65536", "a port past the top of the range"),
+                      ("-1", "a negative port"), ("relay", "a port that is not a number")]:
+    victim = FakeClient(root, "badport_%s" % bad_port.strip("-"), compat=("u", "sp", "r"))
+    reply = relayedhost(root, victim, RELAY_V4, port=bad_port)
+    check(reply.startswith("RELAYEDHOSTFAILED "),
+          "%s should be refused, got %r" % (why, reply))
+    check(victim.relayed_host_ip is None,
+          "%s should leave no address behind, got %r" % (why, victim.relayed_host_ip))
+
+# a client that never asked for relay support has no business naming its own address
+noflag = FakeClient(root, "noflaghost")
+reply = relayedhost(root, noflag, RELAY_V4)
+check(reply.startswith("RELAYEDHOSTFAILED "),
+      "a client without the 'r' flag should be refused, got %r" % (reply,))
+check(noflag.relayed_host_ip is None,
+      "a refused client should hold no address, got %r" % (noflag.relayed_host_ip,))
+
+# and neither has anybody, on a server with no relay to be hosted through
+norelay_root = FakeRoot(relay=False)
+norelay_host = FakeClient(norelay_root, "norelayhost", compat=("u", "sp", "r"))
+reply = relayedhost(norelay_root, norelay_host, RELAY_V4)
+check(reply.startswith("RELAYEDHOSTFAILED "),
+      "a server with no relay should refuse RELAYEDHOST, got %r" % (reply,))
+check(norelay_host.relayed_host_ip is None,
+      "a refused client should hold no address, got %r" % (norelay_host.relayed_host_ip,))
+
+
+# --- every recipient is told the relay, whoever they are ---------------------------
+def hosted(relayed, host_ip=HOST_WAN, host_lan=HOST_LAN):
+    """Open a battle, relayed or not, and hand back what each kind of onlooker was told."""
+    FakeClient._next_session = 1  # the battle channel is named after the host's account id
+    root = FakeRoot()
+    host = FakeClient(root, "host", compat=("u", "sp", "r"), ip=host_ip, local_ip=host_lan)
+    # constructing a client registers it, and broadcast_AddBattle tells all of them
+    FakeClient(root, "samewan", ip=host_ip, local_ip="192.168.1.11")
+    FakeClient(root, "outsider", ip=OUTSIDER)
+    if relayed:
+        relayedhost(root, host, RELAY_V4)
+    openbattle(root, host)
+    return {name: advertised(client) for name, client in root.usernames.items()}
+
+relayed = hosted(relayed=True)
+direct = hosted(relayed=False)
+
+for who in ("host", "samewan", "outsider"):
+    check(battle_address(relayed[who]) == RELAY_V4,
+          "%s should be told the relay address, got %r" % (who, relayed[who]))
+
+# the same-WAN branch is the one it would be tempting to keep, so name what it used to do
+check(battle_address(direct["samewan"]) == HOST_LAN,
+      "without a relay a same-WAN joiner still gets the host's LAN address, got %r" % (direct["samewan"],))
+check(battle_address(direct["outsider"]) == HOST_WAN,
+      "without a relay an outsider still gets the host's WAN address, got %r" % (direct["outsider"],))
+
+# a host the lobby thinks is private is branch 2, and it is wrong under a relay as well
+lan_relayed = hosted(relayed=True, host_ip="10.9.9.9", host_lan="10.9.9.9")
+lan_direct = hosted(relayed=False, host_ip="10.9.9.9", host_lan="10.9.9.9")
+check(battle_address(lan_relayed["outsider"]) == RELAY_V4,
+      "a private-looking relay host should still advertise the relay, got %r" % (lan_relayed["outsider"],))
+check(battle_address(lan_direct["outsider"]) == LOBBY_IP,
+      "without a relay a private-looking host is still advertised at the lobby, got %r" % (lan_direct["outsider"],))
+
+# natType is the whole reason this needs no client support
+for who, line in relayed.items():
+    check(line.split(" ")[3] == "0",
+          "%s should be told natType 0 for a relayed battle, got %r" % (who, line))
+
+# everything but the address is the same line it always was
+def without_address(line):
+    fields = line.split(" ")
+    fields[5] = "IP"
+    return " ".join(fields)
+
+for who in ("host", "samewan", "outsider"):
+    check(without_address(relayed[who]) == without_address(direct[who]),
+          "only the address should differ for %s:\n  %r\n  %r" % (who, relayed[who], direct[who]))
+
+
+# --- the address belongs to one battle and no other -------------------------------
+root = FakeRoot()
+host = FakeClient(root, "twicehost", compat=("u", "sp", "r"))
+relayedhost(root, host, RELAY_V4)
+openbattle(root, host, "first")
+check(battle_address(advertised(host)) == RELAY_V4,
+      "the first battle should be relayed, got %r" % (advertised(host),))
+
+host.sent = []
+openbattle(root, host, "second")
+check(battle_address(advertised(host)) == HOST_WAN,
+      "a second battle with no RELAYEDHOST should be advertised at the host, got %r" % (advertised(host),))
+
+# opening a battle while already in one runs LEAVEBATTLE first, which also forgets an
+# address. The one that arrived with this OPENBATTLE has to survive that.
+root = FakeRoot()
+host = FakeClient(root, "rehost", compat=("u", "sp", "r"))
+openbattle(root, host, "direct first")
+relayedhost(root, host, RELAY_V4)
+host.sent = []
+openbattle(root, host, "relayed second")
+check(battle_address(advertised(host)) == RELAY_V4,
+      "reopening as a relay host should advertise the relay, got %r" % (advertised(host),))
+
+# leaving without opening anything drops it, so it cannot attach itself to a later battle
+root = FakeRoot()
+host = FakeClient(root, "leaverhost", compat=("u", "sp", "r"))
+relayedhost(root, host, RELAY_V4)
+root.protocol.in_LEAVEBATTLE(host)
+check(host.relayed_host_ip is None,
+      "LEAVEBATTLE should forget a pending address, got %r" % (host.relayed_host_ip,))
+host.sent = []
+openbattle(root, host, "after leaving")
+check(battle_address(advertised(host)) == HOST_WAN,
+      "a forgotten address should not reach a later battle, got %r" % (advertised(host),))
+
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("PASS: a relayed battle is advertised at the relay for every recipient, and a battle "
+      "with no RELAYEDHOST is advertised exactly as before")

--- a/tests/worker/turnrelayworkertest.py
+++ b/tests/worker/turnrelayworkertest.py
@@ -19,10 +19,11 @@ _sys.path[:0] = [_ROOT, _os.path.join(_ROOT, "protocol"),
 import base64
 import hashlib
 import hmac
+import logging
 import sys
 import time
 
-from DataHandler import TURN_DEFAULT_TTL, parse_turn_config
+from DataHandler import TURN_CLIENT_MIN_TTL, TURN_DEFAULT_TTL, parse_turn_config
 from protocol import Protocol as ProtocolModule
 
 URI = "turn:relay.example.org:3478"
@@ -96,6 +97,40 @@ rejects(["turn:relay example.org:3478", SECRET], "URI containing a space")
 rejects([URI, SECRET, "twelve hours"], "non-numeric lifetime")
 rejects([URI, SECRET, "0"], "zero lifetime")
 rejects([URI, SECRET, "-1"], "negative lifetime")
+
+
+# --- a lifetime below what clients accept warns, and is still honoured --------------
+# Coilbox refuses a credential shorter than TURN_CLIENT_MIN_TTL, so the operator has to
+# hear about it. It stays a warning because another client may accept less.
+def parse_and_capture(lines):
+    captured = []
+
+    class Collect(logging.Handler):
+        def emit(self, record):
+            captured.append(record.getMessage())
+
+    handler = Collect(level=logging.WARNING)
+    root_logger = logging.getLogger()
+    previous_level = root_logger.level
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.WARNING)
+    try:
+        return parse_turn_config(lines), captured
+    finally:
+        root_logger.removeHandler(handler)
+        root_logger.setLevel(previous_level)
+
+short_config, warned = parse_and_capture([URI, SECRET, str(TURN_CLIENT_MIN_TTL - 1)])
+check(short_config[2] == TURN_CLIENT_MIN_TTL - 1,
+      "a lifetime below the floor should still be honoured, got %r" % (short_config,))
+check(any(str(TURN_CLIENT_MIN_TTL) in w for w in warned),
+      "a lifetime below the floor should warn and name the floor, got %r" % (warned,))
+
+_, at_floor = parse_and_capture([URI, SECRET, str(TURN_CLIENT_MIN_TTL)])
+check(at_floor == [], "a lifetime at the floor should not warn, got %r" % (at_floor,))
+
+_, at_default = parse_and_capture([URI, SECRET])
+check(at_default == [], "the default lifetime should not warn, got %r" % (at_default,))
 
 
 # --- a successful request ----------------------------------------------------------

--- a/tests/worker/turnrelayworkertest.py
+++ b/tests/worker/turnrelayworkertest.py
@@ -1,0 +1,202 @@
+"""
+Worker-unit test for relay hosting (issue #27): the server_turn.txt parser and the
+TURNCREDENTIALS command. Runs fully in-process, no server and no DB needed.
+
+The wire contract is fixed by the shipped coilbox client: a success reply is exactly four
+space-separated fields and the client silently drops the line if any of them is empty or
+contains a space, so the field checks here are correctness checks, not tidiness.
+
+The credential itself is draft-uberti-behave-turn-rest-00. This test recomputes the HMAC
+independently of the server code, so a change to how the password is derived fails here
+rather than at a coturn nobody is watching.
+
+Run: activate the venv, then python3 tests/worker/turnrelayworkertest.py
+"""
+import os as _os, sys as _sys
+_ROOT = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir))
+_sys.path[:0] = [_ROOT, _os.path.join(_ROOT, "protocol"),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+import base64
+import hashlib
+import hmac
+import sys
+import time
+
+from DataHandler import TURN_DEFAULT_TTL, parse_turn_config
+from protocol import Protocol as ProtocolModule
+
+URI = "turn:relay.example.org:3478"
+SECRET = "a_long_random_string"
+USER_ID = 4242
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class FakeRoot:
+    """Just the parts of DataHandler that Protocol touches for this command."""
+    def __init__(self, uri=URI, secret=SECRET, ttl=TURN_DEFAULT_TTL):
+        self.turn_uri = uri
+        self.turn_secret = secret
+        self.turn_ttl = ttl
+        self.recent_turn_credentials = {}
+        self.SayHooks = None
+    def turn_enabled(self):
+        return bool(self.turn_uri and self.turn_secret)
+    def getUserDB(self): pass
+    def getVerificationDB(self): pass
+    def getBanDB(self): pass
+    def getContentDB(self): pass
+
+
+class FakeClient:
+    def __init__(self):
+        self.sent = []
+        self.user_id = USER_ID
+        self.session_id = 1
+        self.username = "relaytester"
+    def Send(self, data, command=None):
+        self.sent.append(data)
+
+
+def ask(root):
+    """Send TURNCREDENTIALS and hand back the single reply line."""
+    client = FakeClient()
+    ProtocolModule.Protocol(root).in_TURNCREDENTIALS(client)
+    return client.sent[-1] if client.sent else ""
+
+
+def compflags(root):
+    client = FakeClient()
+    ProtocolModule.Protocol(root).in_LISTCOMPFLAGS(client)
+    return client.sent[-1].split()[1:]
+
+
+# --- the config parser -------------------------------------------------------------
+check(parse_turn_config([URI, SECRET]) == (URI, SECRET, TURN_DEFAULT_TTL),
+      "two lines should parse to (uri, secret, default ttl), got %r" % (parse_turn_config([URI, SECRET]),))
+check(TURN_DEFAULT_TTL == 43200,
+      "the default lifetime should be 12 hours (43200s), got %r" % (TURN_DEFAULT_TTL,))
+check(parse_turn_config([URI, SECRET, "60"])[2] == 60,
+      "line 3 should set the lifetime")
+check(parse_turn_config(["# a comment", "", URI, SECRET]) == (URI, SECRET, TURN_DEFAULT_TTL),
+      "blank and commented lines should be skipped")
+
+def rejects(lines, label):
+    try:
+        parse_turn_config(lines)
+    except ValueError:
+        return
+    errors.append("malformed config should raise ValueError: %s" % label)
+
+rejects([], "empty file")
+rejects([URI], "URI but no secret")
+rejects(["turn:relay example.org:3478", SECRET], "URI containing a space")
+rejects([URI, SECRET, "twelve hours"], "non-numeric lifetime")
+rejects([URI, SECRET, "0"], "zero lifetime")
+rejects([URI, SECRET, "-1"], "negative lifetime")
+
+
+# --- a successful request ----------------------------------------------------------
+root = FakeRoot()
+before = int(time.time())
+reply = ask(root)
+after = int(time.time())
+
+parts = reply.split(" ")
+check(parts[0] == "TURNCREDENTIALS", "success reply should start with TURNCREDENTIALS, got %r" % (reply,))
+check(len(parts) == 5,
+      "reply should be the command plus exactly 4 fields, got %d fields: %r" % (len(parts) - 1, reply))
+
+if len(parts) == 5:
+    _, uri, username, password, ttl_field = parts
+    check(uri == URI, "field 1 should be the configured URI, got %r" % (uri,))
+    for name, field in (("uri", uri), ("username", username), ("password", password)):
+        check(field != "", "%s must not be empty" % name)
+        check(not any(c.isspace() for c in field), "%s must not contain whitespace: %r" % (name, field))
+
+    # ttl: a plain base-10 integer, and the default lifetime
+    check(ttl_field == str(TURN_DEFAULT_TTL),
+          "ttl field should be %d, got %r" % (TURN_DEFAULT_TTL, ttl_field))
+    check(ttl_field.isdigit() and int(ttl_field) == TURN_DEFAULT_TTL,
+          "ttl field must parse as a plain integer, got %r" % (ttl_field,))
+
+    # username: "<unix expiry>:<account id>", expiring one lifetime from now
+    check(username.count(":") == 1, "username should be '<expiry>:<account id>', got %r" % (username,))
+    expiry_str, uid_str = username.split(":")
+    check(uid_str == str(USER_ID), "username should carry the account id, got %r" % (uid_str,))
+    expiry = int(expiry_str)
+    check(before + TURN_DEFAULT_TTL <= expiry <= after + TURN_DEFAULT_TTL,
+          "expiry should be now + %ds, got %d (now was %d..%d)" % (TURN_DEFAULT_TTL, expiry, before, after))
+
+    # password: recomputed here rather than trusted
+    expected = base64.b64encode(
+        hmac.new(SECRET.encode("utf-8"), username.encode("utf-8"), hashlib.sha1).digest()).decode("utf-8")
+    check(password == expected,
+          "password should be base64(hmac_sha1(secret, username)), got %r, expected %r" % (password, expected))
+    check(password != base64.b64encode(
+        hmac.new(b"wrong_secret", username.encode("utf-8"), hashlib.sha1).digest()).decode("utf-8"),
+        "password must depend on the configured secret")
+
+
+# --- the lifetime is the operator's, not a constant --------------------------------
+short = FakeRoot(ttl=90)
+before = int(time.time())
+parts = ask(short).split(" ")
+check(len(parts) == 5 and parts[4] == "90", "a configured lifetime should reach the wire, got %r" % (parts,))
+if len(parts) == 5:
+    check(int(parts[2].split(":")[0]) - before == 90,
+          "expiry should move with the configured lifetime, got %r" % (parts[2],))
+
+
+# --- rate limit --------------------------------------------------------------------
+root = FakeRoot()
+burst = [ask(root) for _ in range(4)]
+check(all(r.startswith("TURNCREDENTIALS ") for r in burst[:3]),
+      "the first 3 requests should succeed, got %r" % (burst[:3],))
+check(burst[3].startswith("TURNCREDENTIALSFAILED "),
+      "the 4th request in a burst should be refused, got %r" % (burst[3],))
+check(len(burst[3].split(" ", 1)[1].strip()) > 0,
+      "a refusal should carry a reason a person can act on, got %r" % (burst[3],))
+check(root.recent_turn_credentials[USER_ID] == 3,
+      "a refused request should not burn a further slot, counter is %r" % (root.recent_turn_credentials,))
+
+# the counter decays (server.py runs decrement_dict on a loop), and then it works again
+root.recent_turn_credentials[USER_ID] -= 1
+check(ask(root).startswith("TURNCREDENTIALS "), "a decayed counter should allow another credential")
+
+
+# --- no relay configured -----------------------------------------------------------
+for label, root in (("no uri", FakeRoot(uri=None)),
+                    ("no secret", FakeRoot(secret=None)),
+                    ("neither", FakeRoot(uri=None, secret=None))):
+    reply = ask(root)
+    check(reply.startswith("TURNCREDENTIALSFAILED "),
+          "%s should fail cleanly, got %r" % (label, reply))
+
+
+# --- a URI that would shift the fields is refused, not sent ------------------------
+# parse_turn_config rejects this at startup, so reaching it means the config was set some
+# other way. Either way a malformed success line must never go out.
+reply = ask(FakeRoot(uri="turn:relay example.org:3478"))
+check(reply.startswith("TURNCREDENTIALSFAILED "),
+      "a URI containing a space should be refused, not shifted onto the wire, got %r" % (reply,))
+
+
+# --- LISTCOMPFLAGS advertises 'r' only when there is a relay -----------------------
+configured = compflags(FakeRoot())
+unconfigured = compflags(FakeRoot(uri=None, secret=None))
+check("r" in configured, "COMPFLAGS should advertise 'r' when a relay is configured, got %r" % (configured,))
+check("r" not in unconfigured, "COMPFLAGS should omit 'r' when no relay is configured, got %r" % (unconfigured,))
+check([f for f in configured if f != "r"] == unconfigured,
+      "only 'r' should differ between the two, got %r vs %r" % (configured, unconfigured))
+check("r" in ProtocolModule.flag_map and "r" in ProtocolModule.optional_flags,
+      "'r' must stay a known optional flag on every server, whatever the config")
+
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("PASS: server_turn.txt parses, TURNCREDENTIALS mints a valid credential, and 'r' is advertised only when configured")

--- a/turnserver.conf.example
+++ b/turnserver.conf.example
@@ -120,6 +120,19 @@ denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 # here needs them, and leaving them on is transit you are not using.
 no-tcp-relay
 
+# Do not add server-relay. This file leaves it out on purpose and it should stay
+# that way. The option stops coturn checking permissions at all, for every
+# allocation on the server, so anybody who can reach the relay can send through
+# any allocation on it.
+#
+# Somebody will reach for it eventually, and here is the reason they will. A
+# relayed player whose IP changes mid-game is cut off, because the permission
+# the host installed names the address that player has left, and there is no fix
+# available on the client side (tomjn/coilbox#2082). server-relay would be a fix,
+# since it drops the check that is failing. It is still not a trade worth making.
+# It weakens every allocation on the relay to work round something that affects
+# one player at a time.
+
 # ── TLS ───────────────────────────────────────────────────────────────────────
 #
 # TURN over TLS and DTLS, worth having for players whose network blocks plain

--- a/turnserver.conf.example
+++ b/turnserver.conf.example
@@ -1,0 +1,146 @@
+# ── coturn config for uberserver relay hosting ────────────────────────────────
+#
+# Copy this to turnserver.conf and edit it before you run anything:
+#
+#     cp turnserver.conf.example turnserver.conf
+#
+# turnserver.conf is gitignored, because the finished file holds your shared
+# secret. This example file must never hold a real one.
+#
+# Every value tagged EXAMPLE below is a deployment choice with no correct
+# answer. The arithmetic for working out your own is in the README, under
+# "Relay Hosting (TURN)". Do not ship these numbers unread.
+#
+# Defaults quoted in the comments are coturn 4.17.2's own, taken from
+# `turnserver -h` and the turnserver.conf.default shipped with it. Check them
+# against your version.
+
+# ── Listening ─────────────────────────────────────────────────────────────────
+
+# Plain STUN/TURN over UDP and TCP. coturn's default is 3478, and the turn: URI
+# on line 1 of the lobby's server_turn.txt has to name the same port.
+listening-port=3478
+
+# EXAMPLE. Left unset, coturn listens on every address it finds. Set it if the
+# machine has several addresses and you want the relay on one of them.
+#listening-ip=203.0.113.10
+
+# Set this if the relay is behind NAT, which includes most cloud VPS instances
+# with a mapped public address. Left unset, coturn signals the address it is
+# bound to, and if that is the private one the allocation is unreachable. The
+# NAT has to forward each relay port to the same port number.
+#external-ip=203.0.113.10
+#external-ip=203.0.113.10/10.0.0.5
+
+# EXAMPLE. coturn needs a realm for long-term credentials. The value is not part
+# of the credential the lobby mints, so anything works; the relay's own hostname
+# is the usual choice. Without one coturn falls back to the host domain name.
+realm=relay.example.org
+
+# ── Credentials ───────────────────────────────────────────────────────────────
+
+# The lobby mints credentials with draft-uberti-behave-turn-rest-00 and coturn
+# recomputes the same HMAC from the secret below, so the two processes never
+# talk to each other and neither keeps session state.
+use-auth-secret
+
+# MUST be byte for byte the same string as line 2 of the lobby's
+# server_turn.txt. Nothing anywhere detects a mismatch. coturn answers 401 to
+# every credential and every relayed battle fails to start.
+#
+# Generate one:  openssl rand -hex 32
+static-auth-secret=REPLACE_ME_BEFORE_USE
+
+# ── Allocation port range ─────────────────────────────────────────────────────
+
+# One UDP port per allocation, one allocation per relayed battle, so the size of
+# this range is your ceiling on concurrent relayed battles.
+#
+# coturn's defaults are min-port=49152 and max-port=65535, per RFC 5766, which
+# is 16384 ports. Every port in the range has to be open in the firewall, so a
+# range you have sized deliberately is easier to operate than the default one.
+#
+# EXAMPLE, 250 ports for 250 concurrent relayed battles:
+min-port=49152
+max-port=49401
+
+# ── Quotas ────────────────────────────────────────────────────────────────────
+#
+# All four of these default to 0, meaning unlimited. Unlimited is what makes an
+# open relay: anyone holding an account on your lobby can use it as free transit
+# for whatever they like, and nothing in the game caps them. Set all four.
+
+# Concurrent allocations per lobby account. One relayed battle needs one.
+# Leave headroom above that: a host whose allocation is refused after a coturn
+# restart builds a new one, and the old one may not have expired yet.
+#
+# EXAMPLE:
+user-quota=2
+
+# Concurrent allocations across the whole server. Keep this at or below the size
+# of the port range above, so you run out of quota rather than out of ports.
+#
+# EXAMPLE, matching the 250 port range above:
+total-quota=250
+
+# Bytes per second per allocation, counted separately for each direction. This
+# is the setting that stops one session saturating the link. Size it from the
+# engine's own ceiling, worked out in the README: 1048576 B/s covers a 16 player
+# battle. Set it below what a battle actually needs and you silently drop game
+# traffic, which looks like lag rather than like a misconfiguration.
+#
+# EXAMPLE, 16 players:
+max-bps=1048576
+
+# Bytes per second across the whole server, counted separately for each
+# direction. Size it from what the machine's link and your egress bill can
+# stand, not from a number copied out of here.
+#
+# EXAMPLE, 20 concurrent 16 player battles:
+bps-capacity=20971520
+
+# ── Peers ─────────────────────────────────────────────────────────────────────
+
+# A relay forwards to any address it can reach unless told otherwise. On a
+# machine shared with the lobby that includes the lobby itself, the database,
+# and everything else on the private network. Deny the private ranges.
+#
+# coturn already denies loopback peers by default. It does not deny anything
+# else. Add your own ranges if the relay sits on a network with more on it.
+no-multicast-peers
+denied-peer-ip=10.0.0.0-10.255.255.255
+denied-peer-ip=172.16.0.0-172.31.255.255
+denied-peer-ip=192.168.0.0-192.168.255.255
+denied-peer-ip=169.254.0.0-169.254.255.255
+denied-peer-ip=100.64.0.0-100.127.255.255
+denied-peer-ip=fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+# TCP relay endpoints (RFC 6062) are on by default. A battle is UDP, so nothing
+# here needs them, and leaving them on is transit you are not using.
+no-tcp-relay
+
+# ── TLS ───────────────────────────────────────────────────────────────────────
+#
+# TURN over TLS and DTLS, worth having for players whose network blocks plain
+# UDP to unusual ports. coturn's default port is 5349. Uncomment all three lines
+# together: set tls-listening-port without a usable certificate and coturn logs
+# an error and does not listen on it.
+#
+# Point cert and pkey at a certificate from a CA the players' clients already
+# trust, whose name matches the host in the URI on line 1 of server_turn.txt.
+# The lobby's own self-signed server.pem is not a substitute: a client that
+# checks the chain will refuse it.
+#
+# coturn reads these once at startup. SIGHUP only reopens the log file, so a
+# renewal needs a restart.
+#
+#tls-listening-port=5349
+#cert=/etc/coturn/turn_cert.pem
+#pkey=/etc/coturn/turn_pkey.pem
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+
+# stdout, so `docker compose logs coturn` shows it. Running coturn outside a
+# container, put a path here instead and set simple-log if logrotate handles it.
+log-file=stdout


### PR DESCRIPTION
Stacked on `relay-hosting/setup-runbook`, so this diff shows that branch's commits until #49 merges.

Answers the question coilbox raised on #36: whether it may rely on `RELAYEDHOSTFAILED` being written before the answer to the `OPENBATTLE` behind it. It may. `in_RELAYEDHOST` replies where the line is read and the next line's handler runs after it returns. Now stated in section 7.1 rather than assumed on the client side, and pinned by a test, since a promise nothing checks drifts.

Also documents the thing that caught coilbox out. The two lines routinely share a TCP segment, and its first attempt kept the refusal in a slot the battle acknowledgement then overwrote, so the host was told an unrelayed battle was relayed.

Both verified rather than restated: against an unconfigured server the refusal arrived ahead of `OPENBATTLE`, and the refusal plus the whole battle-open sequence came back in one 405 byte read. Deferring the refusal by half a second makes the test fail.
