### PR TITLE
Let a player send a tweak set to an uberserver hosted battle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           python protocol/Protocol.py
           python SQLUsers.py
+          python Client.py
       # NOTE: the pytest suite under tests/ (worker + e2e tiers, plus its conftest fixtures and a
       # MariaDB service) is committed and works, but is NOT gated here yet. Several tiers exercise
       # Phase-3 slices whose implementations live in other, not-yet-merged PRs, and the e2e tier

--- a/Client.py
+++ b/Client.py
@@ -2,6 +2,36 @@ import time, datetime, ip2country
 import logging
 
 
+# Spring and Recoil players change unit stats for one battle by sending SPADS a compiled
+# tweak set as chat, split over numbered slots: "!bset tweakdefs<n> <base64>". A slot is
+# 16000 base64 characters in the tooling players use today, far over any account's normal
+# message length, so those two commands get their own limit. Teiserver allows 16385 for the
+# same payload. The number here also has to cover the "SAYBATTLE " prefix, which teiserver's
+# equivalent check has already stripped.
+TWEAK_MSG_LENGTH = 16384
+TWEAK_COMMAND_PREFIXES = ('!bset tweakdefs', '!bset tweakunits')
+
+def command_length_limit(command, flood_limits, logged_in):
+	'the message length limit that applies to one raw command line'
+	limit = flood_limits['msglength']
+	if not logged_in:
+		return limit
+
+	# the line is still raw here: it may carry a "#<id> " message id, and the command
+	# name is whatever case the client sent it in
+	if command.startswith('#'):
+		msg_id, _, rest = command.partition(' ')
+		if msg_id[1:].isdigit():
+			command = rest
+
+	name, _, msg = command.partition(' ')
+	if name.upper() not in ('SAYBATTLE', 'SAYBATTLEEX'):
+		return limit
+	if not msg.lower().startswith(TWEAK_COMMAND_PREFIXES):
+		return limit
+	return max(limit, TWEAK_MSG_LENGTH)
+
+
 class Client():
 	'this object represents one server-side connected client'
 
@@ -193,8 +223,9 @@ class Client():
 			commands_buffer += strip_commands
 
 		for command in commands_buffer:
-			if len(command) > flood_limits['msglength']:
-				self.Send('SERVERMSG message length limit of %i chars was exceeded: command \"%s...\" dropped.' % (flood_limits['msglength'], command[0: 16]))
+			length_limit = command_length_limit(command, flood_limits, self.logged_in)
+			if len(command) > length_limit:
+				self.Send('SERVERMSG message length limit of %i chars was exceeded: command \"%s...\" dropped.' % (length_limit, command[0: 16]))
 				self.ReportFloodBreach("max message length (cmd=%s...)" % command[0: 16], len(command))
 				continue
 			self.HandleProtocolCommand(command)
@@ -254,4 +285,55 @@ class Client():
 		
 	def isHosting(self):
 		return self.current_battle and self._root.battles[self.current_battle].host == self.session_id
-		
+
+
+def selftest():
+	limits = {'msglength': 10000}
+	payload = 'A' * 16000
+
+	def limit_for(cmd, logged_in = True):
+		return command_length_limit(cmd, limits, logged_in)
+
+	# tweak commands get the raised limit, on both say paths and with a message id
+	assert(limit_for('SAYBATTLE !bset tweakunits1 ' + payload) == TWEAK_MSG_LENGTH)
+	assert(limit_for('SAYBATTLEEX !bset tweakdefs10 ' + payload) == TWEAK_MSG_LENGTH)
+	assert(limit_for('#42 SAYBATTLE !bset tweakdefs1 ' + payload) == TWEAK_MSG_LENGTH)
+	assert(limit_for('saybattle !bset TweakUnits1 ' + payload) == TWEAK_MSG_LENGTH)
+
+	# everything else stays on the account limit
+	assert(limit_for('SAYBATTLE hello') == limits['msglength'])
+	assert(limit_for('SAY #main !bset tweakdefs1 ' + payload) == limits['msglength'])
+	assert(limit_for('SAYPRIVATE host !bset tweakdefs1 ' + payload) == limits['msglength'])
+	assert(limit_for('SAYBATTLE !bset tweakdefs1 ' + payload, False) == limits['msglength'])
+
+	# the raise never lowers an account limit that is already higher
+	assert(command_length_limit('SAYBATTLE !bset tweakdefs1', {'msglength': 99999}, True) == 99999)
+
+	# and the length check in HandleProtocolCommands uses it
+	class FakeClient(Client):
+		def __init__(self):
+			self.data = ''
+			self.logged_in = True
+			self.handled = []
+			self.sent = []
+		def HandleProtocolCommand(self, cmd):
+			self.handled.append(cmd)
+		def Send(self, data, command = None):
+			self.sent.append(data)
+		def ReportFloodBreach(self, type, bytes):
+			pass
+
+	tweak = FakeClient()
+	tweak.HandleProtocolCommands(['SAYBATTLE !bset tweakunits1 ' + payload, ''], limits)
+	assert(len(tweak.handled) == 1)
+	assert(tweak.sent == [])
+
+	chat = FakeClient()
+	chat.HandleProtocolCommands(['SAYBATTLE ' + payload, ''], limits)
+	assert(chat.handled == [])
+	assert(len(chat.sent) == 1)
+
+	print("Client.py selftest passed")
+
+if __name__ == '__main__':
+	selftest()

--- a/Client.py
+++ b/Client.py
@@ -11,12 +11,8 @@ import logging
 TWEAK_MSG_LENGTH = 16384
 TWEAK_COMMAND_PREFIXES = ('!bset tweakdefs', '!bset tweakunits')
 
-def command_length_limit(command, flood_limits, logged_in):
-	'the message length limit that applies to one raw command line'
-	limit = flood_limits['msglength']
-	if not logged_in:
-		return limit
-
+def is_tweak_command(command):
+	'whether one raw command line is a SPADS tweak set going to a battle'
 	# the line is still raw here: it may carry a "#<id> " message id, and the command
 	# name is whatever case the client sent it in
 	if command.startswith('#'):
@@ -26,10 +22,30 @@ def command_length_limit(command, flood_limits, logged_in):
 
 	name, _, msg = command.partition(' ')
 	if name.upper() not in ('SAYBATTLE', 'SAYBATTLEEX'):
-		return limit
-	if not msg.lower().startswith(TWEAK_COMMAND_PREFIXES):
+		return False
+	return msg.lower().startswith(TWEAK_COMMAND_PREFIXES)
+
+def command_length_limit(command, flood_limits, logged_in):
+	'the message length limit that applies to one raw command line'
+	limit = flood_limits['msglength']
+	if not logged_in or not is_tweak_command(command):
 		return limit
 	return max(limit, TWEAK_MSG_LENGTH)
+
+def tweak_command_bytes(lines, logged_in):
+	'''
+	How many of a chunk's bytes belong to tweak commands, and so are charged to the
+	tweak allowance rather than to the byte rate.
+
+	A line over the tweak length limit is dropped later on and never reaches a battle, so
+	it earns no exemption. Without that, a flood only has to wear a tweak command's prefix
+	to escape the byte rate entirely.
+	'''
+	if not logged_in:
+		return 0
+	# each line was charged with the newline that ended it
+	return sum(len(line) + 1 for line in lines
+		if len(line) <= TWEAK_MSG_LENGTH and is_tweak_command(line))
 
 
 class Client():
@@ -88,6 +104,7 @@ class Client():
 		self.msg_sendbuffer = []
 		self.sendingmessage = ''
 		self.msg_length_history = {}
+		self.tweak_length_history = {} # the part of it spent on tweak sets, exempt from the byte rate
 
 		# channels
 		self.channels = set()
@@ -160,30 +177,37 @@ class Client():
 		bytespersecond = flood_limits['bytespersecond']
 		seconds = flood_limits['seconds']
 
+		# keep appending until we see at least one newline
+		self.data += data
+		split_data = self.data.split("\n")
+
 		if (now in self.msg_length_history):
 			self.msg_length_history[now] += len(data)
 		else:
 			self.msg_length_history[now] = len(data)
 
-		total = 0
+		total = self.sumFloodHistory(self.msg_length_history, now, seconds)
+		exempt = self.sumFloodHistory(self.tweak_length_history, now, seconds)
 
-		for iter in dict(self.msg_length_history):
-			if (iter < now - (seconds - 1)):
-				del self.msg_length_history[iter]
-			else:
-				total += self.msg_length_history[iter]
+		# A tweak set is several 16k slots sent back to back, which is over the byte rate of
+		# every account type, so a player sending one would be disconnected partway through.
+		# Those bytes are charged to a separate allowance instead. Once it is spent the rest
+		# is charged as ordinary traffic, so a flood wearing a tweak command's prefix still
+		# meets the same limit it always did. Only the lines this call completed are counted,
+		# and each of them only once.
+		spare = max(0, flood_limits['tweakbytes'] - exempt)
+		tweaked = min(spare, tweak_command_bytes(split_data[: len(split_data) - 1], self.logged_in))
+		self.tweak_length_history[now] = self.tweak_length_history.get(now, 0) + tweaked
+		exempt += tweaked
 
-		if total > (bytespersecond * seconds):
+		if (total - exempt) > (bytespersecond * seconds):
 			self.Send('SERVERMSG No flooding (over %s per second for %s seconds)' % (bytespersecond, seconds))
-			self.ReportFloodBreach("flood limit", total)
+			self.ReportFloodBreach("flood limit", total - exempt)
 			self.Remove('Kicked for flooding (%s)' % (self.access))
 			return
 
-		# keep appending until we see at least one newline
-		self.data += data
-
 		# if far too much data has accumulated without hitting flood limits and without a newline, just clear it
-		if (self.data.count('\n') == 0):
+		if (len(split_data) == 1):
 			if (len(self.data) > (flood_limits['msglength'])*16):
 				del self.data
 				self.data = ""
@@ -191,7 +215,17 @@ class Client():
 				self.ReportFloodBreach("max client data cache ", len(self.data))
 			return
 
-		self.HandleProtocolCommands(self.data.split("\n"), flood_limits)
+		self.HandleProtocolCommands(split_data, flood_limits)
+
+	def sumFloodHistory(self, history, now, seconds):
+		'total of one per-second byte history over the flood window, dropping what fell out of it'
+		total = 0
+		for iter in dict(history):
+			if (iter < now - (seconds - 1)):
+				del history[iter]
+			else:
+				total += history[iter]
+		return total
 
 	def HandleProtocolCommand(self, cmd):
 		# probably caused by trailing newline ("abc\n".split("\n") == ["abc", ""])
@@ -332,6 +366,75 @@ def selftest():
 	chat.HandleProtocolCommands(['SAYBATTLE ' + payload, ''], limits)
 	assert(chat.handled == [])
 	assert(len(chat.sent) == 1)
+
+	# a whole tweak set is several slots sent back to back, far over a player's byte rate
+	rate = {'msglength': 10000, 'bytespersecond': 2000, 'seconds': 10,
+		'tweakbytes': 60 * TWEAK_MSG_LENGTH}
+
+	class FloodClient(Client):
+		def __init__(self, flood_limits, logged_in = True):
+			class FakeRoot:
+				pass
+			self._root = FakeRoot()
+			self._root.flood_limits = {'user': flood_limits, 'fresh': flood_limits}
+			self.bot = False
+			self.access = 'user'
+			self.logged_in = logged_in
+			self.data = ''
+			self.msg_length_history = {}
+			self.tweak_length_history = {}
+			self.handled = []
+			self.sent = []
+			self.removed = []
+		def HandleProtocolCommand(self, cmd):
+			self.handled.append(cmd)
+		def Send(self, data, command = None):
+			self.sent.append(data)
+		def ReportFloodBreach(self, type, bytes):
+			pass
+		def Remove(self, reason = 'Quit'):
+			self.removed.append(reason)
+
+	def slots(n):
+		return ["SAYBATTLE !bset tweakunits%d %s\n" % (i, payload) for i in range(1, n + 1)]
+
+	# five slots, one write each: all delivered, sender still connected
+	paced = FloodClient(rate)
+	for line in slots(5):
+		paced.Handle(line)
+	assert(len(paced.handled) == 5)
+	assert(paced.removed == [])
+
+	# and the same five arriving in one read, which is what a client blasting them looks like
+	coalesced = FloodClient(rate)
+	coalesced.Handle("".join(slots(5)))
+	assert(len(coalesced.handled) == 5)
+	assert(coalesced.removed == [])
+
+	# the byte rate is untouched for everything else: the same volume of ordinary chat
+	# still disconnects the sender
+	flooder = FloodClient(rate)
+	for _ in range(5):
+		flooder.Handle("SAYBATTLE %s\n" % payload)
+	assert(flooder.removed != [])
+
+	# past the allowance, tweak bytes are charged like any others
+	stingy = FloodClient(dict(rate, tweakbytes = 2 * TWEAK_MSG_LENGTH))
+	for line in slots(5):
+		stingy.Handle(line)
+	assert(stingy.removed != [])
+
+	# a line too long to be delivered anyway buys no exemption
+	overlong = FloodClient(rate)
+	for _ in range(5):
+		overlong.Handle("SAYBATTLE !bset tweakunits1 %s\n" % ('A' * TWEAK_MSG_LENGTH))
+	assert(overlong.removed != [])
+
+	# and neither does a tweak command from a client that has not logged in
+	anon = FloodClient(rate, logged_in = False)
+	for line in slots(5):
+		anon.Handle(line)
+	assert(anon.removed != [])
 
 	print("Client.py selftest passed")
 

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -198,12 +198,17 @@ class DataHandler:
 		self.recent_registrations = {} #ip_address->int
 		self.recent_renames = {} #user_id->int
 		self.recent_turn_credentials = {} #user_id->int
+		# tweakbytes is how much of a window's traffic may be SPADS tweak sets, which are far
+		# over the byte rate and would otherwise disconnect the player sending one. Beyond All
+		# Reason declares 60 tweak slots (a bare tweakdefs and tweakunits plus 1..29 of each),
+		# so this is a whole set at the 16384 characters one slot is allowed, and no legitimate
+		# set has to be spread over several windows. Nothing before login gets an allowance.
 		self.flood_limits = {
-			'fresh':{'msglength':1000, 'bytespersecond':1000, 'seconds':2}, # also the default
-			'user':{'msglength':10000, 'bytespersecond':2000, 'seconds':10},
-			'bot':{'msglength':10000, 'bytespersecond':50000, 'seconds':10},
-			'mod':{'msglength':10000, 'bytespersecond':2000, 'seconds':10},
-			'admin':{'msglength':10000, 'bytespersecond':2000, 'seconds':10},
+			'fresh':{'msglength':1000, 'bytespersecond':1000, 'seconds':2, 'tweakbytes':0}, # also the default
+			'user':{'msglength':10000, 'bytespersecond':2000, 'seconds':10, 'tweakbytes':983040},
+			'bot':{'msglength':10000, 'bytespersecond':50000, 'seconds':10, 'tweakbytes':983040},
+			'mod':{'msglength':10000, 'bytespersecond':2000, 'seconds':10, 'tweakbytes':983040},
+			'admin':{'msglength':10000, 'bytespersecond':2000, 'seconds':10, 'tweakbytes':983040},
 		}
 
 	def initlogger(self, filename):

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -54,9 +54,14 @@ cannot drift. **[GAP]** the `@emits` convention does not exist yet — see
   or `!bset tweakunits`, which a logged-in client may send up to 16,384 characters. The
   limit is measured on the whole line, including the command name and any `#<id> ` prefix.
 
-**[GAP]** Confirm the byte-rate limits as seen by clients (the server enforces a
-per-access-level byte rate in `DataHandler.py` `flood_limits` and disconnects a client
-that goes over, so the rate clients should stay under is worth documenting).
+- **Byte rate.** A client over its byte rate is disconnected, having been told so first.
+  The rate is averaged over a window, both from `flood_limits`: 1,000 bytes per second
+  over 2 seconds before login, 2,000 over 10 seconds for `user`, `mod` and `admin`, and
+  50,000 over 10 seconds for a bot account. Tweak sets are the exception again. A whole
+  set is several 16k slots and no player could send one within their rate, so a logged-in
+  client has a separate allowance of 983,040 bytes per window for those two commands,
+  enough for the 60 slots Beyond All Reason declares. Bytes past the allowance count
+  against the byte rate like any others.
 
 ---
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -47,9 +47,16 @@ cannot drift. **[GAP]** the `@emits` convention does not exist yet — see
 - **Connection cap:** the server refuses new connections above `maxclients`, derived
   from half the process file-descriptor limit (`twistedserver.py`).
 
-**[GAP]** Confirm maximum line length / flood limits as seen by clients (the server
-enforces per-access-level byte-rate and message-length limits in `DataHandler.py`
-`flood_limits`; document the values clients should stay under).
+- **Line length.** A command longer than the account's limit is dropped, and the sender
+  gets a `SERVERMSG` naming the limit. The limits are in `DataHandler.py` `flood_limits`:
+  1,000 characters before login, 10,000 for `user`, `bot`, `mod` and `admin`. The one
+  exception is a SPADS tweak set, `SAYBATTLE` or `SAYBATTLEEX` carrying `!bset tweakdefs`
+  or `!bset tweakunits`, which a logged-in client may send up to 16,384 characters. The
+  limit is measured on the whole line, including the command name and any `#<id> ` prefix.
+
+**[GAP]** Confirm the byte-rate limits as seen by clients (the server enforces a
+per-access-level byte rate in `DataHandler.py` `flood_limits` and disconnects a client
+that goes over, so the rate clients should stay under is worth documenting).
 
 ---
 

--- a/tests/integration/tweakmsgtest.py
+++ b/tests/integration/tweakmsgtest.py
@@ -1,0 +1,159 @@
+"""
+End-to-end tier: SPADS tweak commands survive the message length limit (issue #56).
+
+A player changes unit stats for one battle by sending the autohost a compiled tweak set as
+battle chat, "!bset tweakunits<n> <base64>", one command per slot. A slot is 16000 base64
+characters, so before this change every one of them was dropped by the length check in
+Client.HandleProtocolCommands and never reached the battle.
+
+Two properties are checked against a live server. A 16000 character tweak command arrives at
+the host intact, and an ordinary battle message of the same size is still refused with the
+SERVERMSG that names the limit, so the exemption has not turned into a general raise.
+"""
+import os as _os, sys as _sys
+_sys.path[:0] = [_os.path.join(_os.path.dirname(__file__), _os.pardir, _os.pardir),
+                 _os.path.join(_os.path.dirname(__file__), _os.pardir)]
+from testenv import HOST, PORT
+import socket, ssl, hashlib, base64, time, sys
+
+raw_pw = "secretpw"
+PW = base64.b64encode(hashlib.md5(raw_pw.encode()).digest()).decode()
+BATTLE_HOST = "tweakhost"
+TWEAKER = "tweakplayer"
+CHATTER = "tweakchatter"
+PAYLOAD = "A" * 16000  # the size the tooling players use today
+
+# hosting requires TLS (in_OPENBATTLE), and the test server's certificate is self-signed
+CTX = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+errors = []
+def check(cond, label):
+    if not cond: errors.append(label)
+
+
+class Client:
+    def __init__(self):
+        self.s = socket.create_connection((HOST, PORT))
+        self.buf = ""
+        self.read_for(0.5)
+        self.send("STLS")
+        self.read_until("OK", 5)
+        self.s = CTX.wrap_socket(self.s)
+        self.read_for(0.5)
+
+    def send(self, line):
+        self.s.sendall((line + "\n").encode())
+
+    def read_until(self, substr, timeout=8):
+        deadline = time.time() + timeout
+        while substr not in self.buf and time.time() < deadline:
+            self.s.settimeout(max(0.1, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def read_for(self, seconds):
+        """Drain everything that arrives in a fixed window, for streams with no end marker."""
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.s.settimeout(max(0.05, deadline - time.time()))
+            try:
+                chunk = self.s.recv(8192)
+            except (socket.timeout, ssl.SSLWantReadError):
+                break
+            if not chunk:
+                break
+            self.buf += chunk.decode(errors="replace")
+        out, self.buf = self.buf, ""
+        return out
+
+    def close(self):
+        try: self.s.close()
+        except OSError: pass
+
+
+def register(user):
+    c = Client()
+    c.send("REGISTER %s %s" % (user, PW))
+    print("REGISTER %s -> %s" % (user, c.read_until("\n", 5).strip()))
+    c.close()
+
+
+def login(user):
+    c = Client()
+    c.send("LOGIN %s %s 0 * TestClient\t0\tu sp" % (user, PW))
+    got = c.read_until("AGREEMENTEND", 10)
+    if "AGREEMENTEND" in got:
+        c.send("CONFIRMAGREEMENT")
+        got += c.read_until("LOGININFOEND", 10)
+    check("LOGININFOEND" in got, "%s should log in, got:\n%s" % (user, got))
+    return c
+
+
+def join_battle(user, battle_id):
+    c = login(user)
+    c.send("JOINBATTLE %s" % battle_id)
+    got = c.read_until("JOINBATTLE ", 8)
+    check("JOINBATTLEFAILED" not in got, "%s should join the battle, got:\n%s" % (user, got))
+    return c
+
+
+for user in (BATTLE_HOST, TWEAKER, CHATTER):
+    register(user)
+print("waiting 3s for the delayed-registration window...")
+time.sleep(3)
+
+host = login(BATTLE_HOST)
+host.send("OPENBATTLE 0 0 * 30001 8 4660 0 4660 spring\t105.0\tDeltaSiegeDry\ttweak command test\tBA")
+opened = host.read_for(1.5)
+battle_id = None
+for line in opened.splitlines():
+    if line.startswith("BATTLEOPENED "):
+        battle_id = line.split(" ")[1]
+if battle_id is None:
+    print("ABORT: OPENBATTLE produced no BATTLEOPENED, got:\n%s" % opened)
+    sys.exit(1)
+print("battle %s opened" % battle_id)
+
+# a tweak slot, the size a real one is
+tweaker = join_battle(TWEAKER, battle_id)
+host.read_for(0.5)
+tweaker.send("SAYBATTLE !bset tweakunits1 %s" % PAYLOAD)
+tweak_reply = tweaker.read_for(1.5)
+at_host = host.read_for(2.0)
+
+check("message length limit" not in tweak_reply,
+      "the sender should not be told the tweak command was too long, got:\n%s" % tweak_reply[:200])
+check(("!bset tweakunits1 " + PAYLOAD) in at_host,
+      "the host should receive the whole tweak command, got %d chars:\n%s"
+      % (len(at_host), at_host[:200]))
+
+# the same size of ordinary battle chat, which is not a tweak command
+chatter = join_battle(CHATTER, battle_id)
+host.read_for(0.5)
+chatter.send("SAYBATTLE %s" % PAYLOAD)
+chat_reply = chatter.read_for(1.5)
+chat_at_host = host.read_for(2.0)
+
+check("message length limit" in chat_reply,
+      "ordinary chat of the same size should still be refused, got:\n%s" % chat_reply[:200])
+check(PAYLOAD not in chat_at_host,
+      "ordinary chat of the same size should not reach the host, got %d chars" % len(chat_at_host))
+
+for c in (chatter, tweaker, host):
+    c.close()
+
+if errors:
+    print("FAIL (%d):" % len(errors))
+    for e in errors: print("  -", e)
+    sys.exit(1)
+print("RESULT: PASS")
+sys.exit(0)

--- a/tests/integration/tweakmsgtest.py
+++ b/tests/integration/tweakmsgtest.py
@@ -148,6 +148,32 @@ check("message length limit" in chat_reply,
 check(PAYLOAD not in chat_at_host,
       "ordinary chat of the same size should not reach the host, got %d chars" % len(chat_at_host))
 
+# a whole set, sent as fast as the client can write it. Five slots is 80k, four times the
+# 20,000 bytes a user account may send in 10 seconds, so before the allowance existed this
+# disconnected the sender partway through.
+SLOTS = 5
+for n in range(1, SLOTS + 1):
+    tweaker.send("SAYBATTLE !bset tweakdefs%d %s" % (n, PAYLOAD))
+
+seen = ""
+deadline = time.time() + 15
+while time.time() < deadline:
+    seen += host.read_for(1.0)
+    if all(("!bset tweakdefs%d " % n) in seen for n in range(1, SLOTS + 1)):
+        break
+arrived = [n for n in range(1, SLOTS + 1) if ("!bset tweakdefs%d " % n) in seen]
+check(len(arrived) == SLOTS,
+      "the whole set should reach the host, slots that arrived: %s" % arrived)
+
+# and the sender is still there to send the next one
+try:
+    tweaker.send("PING")
+    alive = "PONG" in tweaker.read_until("PONG", 5)
+except OSError as e:
+    alive = False
+    print("PING after the set failed: %s" % e)
+check(alive, "the sender should not have been disconnected for flooding")
+
 for c in (chatter, tweaker, host):
     c.close()
 


### PR DESCRIPTION
Players change unit stats for a single battle by sending the autohost a compiled tweak set as chat, one `!bset tweakdefs<n>` or `!bset tweakunits<n>` command per numbered slot. A slot is about 16k of base64, so every one of them was dropped. There was no way to use tweaks on an uberserver hosted battle at all.

Two limits stood in the way, and both now give way for those two commands only.

The message length limit goes to 16,384 characters for them, matching what teiserver allows for the same payload, and only once the sender has logged in. Unlike teiserver, an over-long command is still refused out loud rather than silently truncated.

The byte rate is the second one, and it only becomes visible once the first is fixed. A set is several slots and a `user` account may send 20,000 bytes per 10 seconds, so the sender was disconnected partway through, with the first slots already delivered and the rest lost. Tweak commands are now charged to their own allowance instead of the byte rate. Bytes past that allowance are charged as ordinary traffic, so a flood wearing a tweak command's prefix meets the same flood control it always did, and a line too long to be delivered earns no exemption at all.

Raising the general limits instead would have been simpler and worse. They are doing a useful job, and this way the only thing that gets through is the thing people are asking for.

One number is worth arguing about. The allowance is 983,040 bytes per window: the 60 tweak slots Beyond All Reason declares in its mod options, at the 16,384 characters a slot may now be. I sized it so that no legitimate set is ever cut in half. The cost is that a logged-in client in a battle can push that much every 10 seconds into a battle channel where the ceiling used to be 20,000, and the server broadcasts it to everyone in the battle. If that is too generous for this server, it is one entry in `flood_limits`, and nothing else about the change depends on the size.

Fixes #56.
